### PR TITLE
chore: clippy --fix

### DIFF
--- a/halo2-base/src/gates/flex_gate.rs
+++ b/halo2-base/src/gates/flex_gate.rs
@@ -802,7 +802,6 @@ impl<F: ScalarField> GateInstructions<F> for FlexGateConfig<F> {
                     .iter()
                     .flat_map(|byte| (0..8).map(|i| (*byte as u64 >> i) & 1))
                     .take(range_bits)
-                    .into_iter()
                     .map(|x| F::from(x))
                     .collect::<Vec<_>>()
             })

--- a/halo2-ecc/src/bigint/mod.rs
+++ b/halo2-ecc/src/bigint/mod.rs
@@ -30,19 +30,17 @@ pub mod sub;
 pub mod sub_no_carry;
 
 #[derive(Clone, Debug, PartialEq)]
+#[derive(Default)]
 pub enum BigIntStrategy {
     // use existing gates
+    #[default]
     Simple,
     // vertical custom gates of length 4 for dot product between an unknown vector and a constant vector, both of length 3
     // we restrict to gate of length 4 since this uses the same set of evaluation points Rotation(0..=3) as our simple gate
     // CustomVerticalShort,
 }
 
-impl Default for BigIntStrategy {
-    fn default() -> Self {
-        BigIntStrategy::Simple
-    }
-}
+
 
 #[derive(Clone, Debug)]
 pub struct OverflowInteger<'v, F: PrimeField> {

--- a/halo2-ecc/src/ecc/fixed_base.rs
+++ b/halo2-ecc/src/ecc/fixed_base.rs
@@ -151,8 +151,8 @@ where
         .flat_map(|scalar_chunk| chip.gate().num_to_bits(ctx, scalar_chunk, max_bits))
         .collect::<Vec<_>>();
 
-    let cached_point_window_rev = cached_points.chunks(1usize << window_bits).into_iter().rev();
-    let bit_window_rev = bits.chunks(window_bits).into_iter().rev();
+    let cached_point_window_rev = cached_points.chunks(1usize << window_bits).rev();
+    let bit_window_rev = bits.chunks(window_bits).rev();
     let mut curr_point = None;
     // `is_started` is just a way to deal with if `curr_point` is actually identity
     let mut is_started = chip.gate().load_zero(ctx);
@@ -261,12 +261,11 @@ where
 
     let sm = cached_points
         .chunks(cached_points.len() / points.len())
-        .into_iter()
-        .zip(bits.chunks(total_bits).into_iter())
+        .zip(bits.chunks(total_bits))
         .map(|(cached_points, bits)| {
             let cached_point_window_rev =
-                cached_points.chunks(1usize << window_bits).into_iter().rev();
-            let bit_window_rev = bits.chunks(window_bits).into_iter().rev();
+                cached_points.chunks(1usize << window_bits).rev();
+            let bit_window_rev = bits.chunks(window_bits).rev();
             let mut curr_point = None;
             // `is_started` is just a way to deal with if `curr_point` is actually identity
             let mut is_started = field_chip.gate().load_zero(ctx);

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -483,8 +483,7 @@ where
         }
         for (cached_points, rounded_bits) in cached_points
             .chunks(cache_size)
-            .into_iter()
-            .zip(rounded_bits.chunks(rounded_bitlen).into_iter())
+            .zip(rounded_bits.chunks(rounded_bitlen))
         {
             let add_point = ec_select_from_bits::<F, FC>(
                 chip,

--- a/halo2-ecc/src/ecc/pippenger.rs
+++ b/halo2-ecc/src/ecc/pippenger.rs
@@ -85,7 +85,7 @@ where
 
     let mut bucket = Vec::with_capacity(1 << c);
     let mut rand_point = rand_base.clone();
-    for (round, points_clump) in points.chunks(c).into_iter().enumerate() {
+    for (round, points_clump) in points.chunks(c).enumerate() {
         // compute all possible multi-products of elements in points[round * c .. round * (c+1)]
 
         // for later addition collision-prevension, we need a different random point per round

--- a/halo2-ecc/src/fields/tests.rs
+++ b/halo2-ecc/src/fields/tests.rs
@@ -90,8 +90,7 @@ mod fp {
                     #[cfg(feature = "display")]
                     {
                         println!(
-                            "Using {} advice columns and {} fixed columns",
-                            NUM_ADVICE, NUM_FIXED
+                            "Using {NUM_ADVICE} advice columns and {NUM_FIXED} fixed columns"
                         );
                         println!("total cells: {}", ctx.total_advice);
 
@@ -224,8 +223,7 @@ mod fp12 {
                     #[cfg(feature = "display")]
                     {
                         println!(
-                            "Using {} advice columns and {} fixed columns",
-                            NUM_ADVICE, NUM_FIXED
+                            "Using {NUM_ADVICE} advice columns and {NUM_FIXED} fixed columns"
                         );
                         println!("total advice cells: {}", ctx.total_advice);
 

--- a/halo2-ecc/src/secp256k1/tests/ecdsa.rs
+++ b/halo2-ecc/src/secp256k1/tests/ecdsa.rs
@@ -13,7 +13,7 @@ use crate::halo2_proofs::{
     halo2curves::bn256::{Bn256, Fr, G1Affine},
     halo2curves::secp256k1::{Fp, Fq, Secp256k1Affine},
     plonk::*,
-    poly::commitment::{Params, ParamsProver},
+    poly::commitment::{ParamsProver},
     transcript::{Blake2bRead, Blake2bWrite, Challenge255},
 };
 use rand_core::OsRng;
@@ -99,9 +99,9 @@ impl<F: PrimeField> Circuit<F> for ECDSACircuit<F> {
 
         let limb_bits = fp_chip.limb_bits;
         let num_limbs = fp_chip.num_limbs;
-        let num_fixed = fp_chip.range.gate.constants.len();
-        let lookup_bits = fp_chip.range.lookup_bits;
-        let num_advice = fp_chip.range.gate.num_advice;
+        let _num_fixed = fp_chip.range.gate.constants.len();
+        let _lookup_bits = fp_chip.range.lookup_bits;
+        let _num_advice = fp_chip.range.gate.num_advice;
 
         let mut first_pass = SKIP_FIRST_PASS;
         // ECDSA verify
@@ -218,7 +218,7 @@ fn bench_secp256_ecdsa() -> Result<(), Box<dyn std::error::Error>> {
 
     use crate::halo2_proofs::{
         poly::kzg::{
-            commitment::{KZGCommitmentScheme, ParamsKZG},
+            commitment::{KZGCommitmentScheme},
             multiopen::{ProverSHPLONK, VerifierSHPLONK},
             strategy::SingleStrategy,
         },
@@ -226,7 +226,7 @@ fn bench_secp256_ecdsa() -> Result<(), Box<dyn std::error::Error>> {
     };
     use std::{env::set_var, fs, io::BufRead};
 
-    let mut rng = OsRng;
+    let _rng = OsRng;
 
     let mut folder = std::path::PathBuf::new();
     folder.push("./src/secp256k1");


### PR DESCRIPTION
apply some clippy fixes via
`cargo +nightly clippy --fix -Z unstable-options --allow-dirty --allow-staged`

there still some hints that require manual changes, for examples needless lifetimes.