### PR TITLE
spec/keccak-decoupling: specs of Keccak split into two chips.

### DIFF
--- a/hashes/zkevm-keccak/src/control.rs
+++ b/hashes/zkevm-keccak/src/control.rs
@@ -1,0 +1,32 @@
+//!
+//! A control chip provides a table of hashes, that is pairs of input messages to digests.
+//!
+//! A control chip is responsible for the following tasks:
+//!
+//! **Table of Hashes**
+//! - Convert between the fixed positions of permutations into the desired positions of data in a user circuit. This is done by exposing the hashes as a table, which user circuits can access with lookup arguments.
+//! - Indicate to user circuits which entries of the table are valid. This is done by exposing a boolean column "enabled", in sync with valid input/digest pairs.
+//!- Prevent confusion between messages that are prefix or suffix of each other.
+//!
+//! **Data Formats**
+//! - Convert the format of input data in user circuits, into initial states.
+//! - Convert the format of final states into output digests in user circuits.
+//! - Pad variable-length inputs, as per the sponge method.
+//!
+//! **Control of the Permutations**
+//! - Decide where to start a new hash, and where to chain consecutive permutations to hash long messages. This is done by some logic on the message length.
+//! - At the start of a hash, set an initial state to the first chunk of a message.
+//! - To continue a hash, XOR the previous final state with the next input chunk.
+//! - Deduplicate identical inputs.
+//! - Fill unused permutations.
+//!
+//! **The Keccak-RLC control chip**
+//!
+//! This chip exposes Keccak hashes, where both the input messages and the digests are identified by RLC values.
+//!
+//! - A hash entries in the exposed table is a tuple on a single row: (input_rlc, input_length, digest_rlc, enabled=true).
+//! - Permutations are implemented by the Keccak-f chip.
+//! - Convert: RLC of the message <=> vector of bytes <=> chunks of 17 words in fat-bit encoding.
+//! - Convert: RLC of the digest <=> 32 bytes <=> 4 words in fat-bit encoding.
+//! - The RLC values are computed using the challenge API, in a second phase after the permutations.
+//!

--- a/hashes/zkevm-keccak/src/keccak_f.rs
+++ b/hashes/zkevm-keccak/src/keccak_f.rs
@@ -1,0 +1,15 @@
+//!
+//! The Keccak-f Chip provides a sequence of initial/final states connected by the Keccak-f permutation (1600 bits).
+//!
+//! This chip creates a fixed layout containing a sequence of regions that implement Keccak-f. As many regions as possible are fitted given target height parameters.
+//!
+//! The chip *config* exposes the positions of initial/final states within a region (column, offset), and the positions of all initial/final states within a circuit (rows). Regions are separated by a minimum number of rows, predictable based on the height parameters.
+//!
+//! The states are encoded in the native efficient format of the chip. A state is 25 cells, each holding a word of 64 bits. Words use a fat encoding where each bit takes up 3 bits worth of space:
+//!
+//!     word = ∑( bits[i] * (1 << 3*i) )
+//!
+//! The chip produces this format in final states. However, the constraints on, and the content of the initial states are the responsibility of a control chip. The Keccak-f synthesis receives initial state values from a control chip.
+//!
+//! If some regions are not used, they should be filled by applying the permutation on the zero initial state. The chip provides a function to do this efficiently.
+//!

--- a/hashes/zkevm-keccak/src/lib.rs
+++ b/hashes/zkevm-keccak/src/lib.rs
@@ -8,4 +8,7 @@ pub mod keccak_packed_multi;
 /// Util
 pub mod util;
 
+pub mod keccak_f;
+pub mod control;
+
 pub use keccak_packed_multi::KeccakCircuitConfig as KeccakConfig;


### PR DESCRIPTION
This is a proposal on how to decouple the Keccak circuit.

Goals:

- Facilitate a common codebase with identical core components, but different interfaces.

- Improve readability and auditability. Example: input processing is blended within the round logic, which is complex and confusing.

- Open the way for more refactoring and optimizations, in particular in the control chip. Example, again input processing.