### PR TITLE
Fix: `inner_product_left_last` size hint

### DIFF
--- a/halo2-base/src/gates/flex_gate.rs
+++ b/halo2-base/src/gates/flex_gate.rs
@@ -759,7 +759,7 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
     {
         let a = a.into_iter();
         let (len, hi) = a.size_hint();
-        debug_assert_eq!(Some(len), hi);
+        assert_eq!(Some(len), hi);
         let row_offset = ctx.advice.len();
         let b_starts_with_one = self.inner_product_simple(ctx, a, b);
         let a_last = if b_starts_with_one {


### PR DESCRIPTION
The length of input iterator is only checked via size hint and `debug_assert_eq!`. Since this length is used to compute the advice offset of a returned cell, for safety we should use `assert_eq!`.