### PR TITLE
Smart Range Builder

### DIFF
--- a/halo2-base/src/gates/builder.rs
+++ b/halo2-base/src/gates/builder.rs
@@ -646,7 +646,12 @@ impl<F: ScalarField> Circuit<F> for RangeCircuitBuilder<F> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        config.load_lookup_table(&mut layouter).expect("load lookup table should not fail");
+        // only load lookup table if we are actually doing lookups
+        if config.lookup_advice.iter().map(|a| a.len()).sum::<usize>() != 0
+            || !config.q_lookup.iter().all(|q| q.is_none())
+        {
+            config.load_lookup_table(&mut layouter).expect("load lookup table should not fail");
+        }
         self.0.sub_synthesize(&config.gate, &config.lookup_advice, &config.q_lookup, &mut layouter);
         Ok(())
     }

--- a/halo2-base/src/gates/builder.rs
+++ b/halo2-base/src/gates/builder.rs
@@ -14,6 +14,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::{HashMap, HashSet},
+    env::{set_var, var},
 };
 
 /// Vector of thread advice column break points
@@ -180,7 +181,7 @@ impl<F: ScalarField> GateThreadBuilder<F> {
             println!("Total {total_fixed} fixed cells");
             log::info!("Auto-calculated config params:\n {params:#?}");
         }
-        std::env::set_var("FLEX_GATE_CONFIG_PARAMS", serde_json::to_string(&params).unwrap());
+        set_var("FLEX_GATE_CONFIG_PARAMS", serde_json::to_string(&params).unwrap());
         params
     }
 
@@ -568,7 +569,7 @@ impl<F: ScalarField> Circuit<F> for GateCircuitBuilder<F> {
             num_lookup_advice_per_phase: _,
             num_fixed,
             k,
-        } = serde_json::from_str(&std::env::var("FLEX_GATE_CONFIG_PARAMS").unwrap()).unwrap();
+        } = serde_json::from_str(&var("FLEX_GATE_CONFIG_PARAMS").unwrap()).unwrap();
         FlexGateConfig::configure(meta, strategy, &num_advice_per_phase, num_fixed, k)
     }
 
@@ -624,11 +625,11 @@ impl<F: ScalarField> Circuit<F> for RangeCircuitBuilder<F> {
             num_lookup_advice_per_phase,
             num_fixed,
             k,
-        } = serde_json::from_str(&std::env::var("FLEX_GATE_CONFIG_PARAMS").unwrap()).unwrap();
+        } = serde_json::from_str(&var("FLEX_GATE_CONFIG_PARAMS").unwrap()).unwrap();
         let strategy = match strategy {
             GateStrategy::Vertical => RangeStrategy::Vertical,
         };
-        let lookup_bits = std::env::var("LOOKUP_BITS").unwrap().parse().unwrap();
+        let lookup_bits = var("LOOKUP_BITS").unwrap_or_else(|_| "0".to_string()).parse().unwrap();
         RangeConfig::configure(
             meta,
             strategy,

--- a/halo2-base/src/gates/builder.rs
+++ b/halo2-base/src/gates/builder.rs
@@ -781,7 +781,7 @@ impl<F: ScalarField> Circuit<F> for RangeWithInstanceCircuitBuilder<F> {
 }
 
 /// Defines stage of the circuit builder.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CircuitBuilderStage {
     /// Keygen phase
     Keygen,

--- a/halo2-base/src/gates/mod.rs
+++ b/halo2-base/src/gates/mod.rs
@@ -1,7 +1,11 @@
+/// Module that helps auto-build circuits
 pub mod builder;
+/// Module implementing our simple custom gate and common functions using it
 pub mod flex_gate;
+/// Module using a single lookup table for range checks
 pub mod range;
 
+/// Tests
 #[cfg(any(test, feature = "test-utils"))]
 pub mod tests;
 

--- a/halo2-base/src/gates/tests/mod.rs
+++ b/halo2-base/src/gates/tests/mod.rs
@@ -17,7 +17,7 @@ mod general;
 #[cfg(test)]
 mod idx_to_indicator;
 
-// helper functions
+/// helper function to generate a proof with real prover
 pub fn gen_proof(
     params: &ParamsKZG<Bn256>,
     pk: &ProvingKey<G1Affine>,
@@ -36,6 +36,7 @@ pub fn gen_proof(
     transcript.finalize()
 }
 
+/// helper function to verify a proof
 pub fn check_proof(
     params: &ParamsKZG<Bn256>,
     vk: &VerifyingKey<G1Affine>,

--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -1,3 +1,4 @@
+//! Base library to build Halo2 circuits.
 #![feature(stmt_expr_attributes)]
 #![feature(trait_alias)]
 #![deny(clippy::perf)]
@@ -40,6 +41,7 @@ pub mod gates;
 /// Utility functions for converting between different types of field elements.
 pub mod utils;
 
+/// Constant representing whether the Layouter calls `synthesize` once just to get region shape.
 #[cfg(feature = "halo2-axiom")]
 pub const SKIP_FIRST_PASS: bool = false;
 #[cfg(feature = "halo2-pse")]
@@ -72,7 +74,7 @@ impl<F: ScalarField> From<AssignedValue<F>> for QuantumCell<F> {
 
 impl<F: ScalarField> QuantumCell<F> {
     /// Returns an immutable reference to the underlying [ScalarField] value of a QuantumCell<F>.
-    /// 
+    ///
     /// Panics if the QuantumCell<F> is of type WitnessFraction.
     pub fn value(&self) -> &F {
         match self {
@@ -96,7 +98,7 @@ pub struct ContextCell {
 }
 
 /// Pointer containing cell value and location within [Context].
-/// 
+///
 /// Note: Performs a copy of the value, should only be used when you are about to assign the value again elsewhere.
 #[derive(Clone, Copy, Debug)]
 pub struct AssignedValue<F: ScalarField> {
@@ -109,7 +111,7 @@ pub struct AssignedValue<F: ScalarField> {
 
 impl<F: ScalarField> AssignedValue<F> {
     /// Returns an immutable reference to the underlying value of an AssignedValue<F>.
-    /// 
+    ///
     /// Panics if the AssignedValue<F> is of type WitnessFraction.
     pub fn value(&self) -> &F {
         match &self.value {
@@ -123,7 +125,6 @@ impl<F: ScalarField> AssignedValue<F> {
 /// * We keep the naming [Context] for historical reasons.
 #[derive(Clone, Debug)]
 pub struct Context<F: ScalarField> {
-
     /// Flag to determine whether only witness generation or proving and verification key generation is being performed.
     /// * If witness gen is performed many operations can be skipped for optimization.
     witness_gen_only: bool,
@@ -134,7 +135,7 @@ pub struct Context<F: ScalarField> {
     /// Single column of advice cells.
     pub advice: Vec<Assigned<F>>,
 
-    /// [Vec] tracking all cells that lookup is enabled for. 
+    /// [Vec] tracking all cells that lookup is enabled for.
     /// * When there is more than 1 advice column all `advice` cells will be copied to a single lookup enabled column to perform lookups.
     pub cells_to_lookup: Vec<AssignedValue<F>>,
 
@@ -156,12 +157,12 @@ pub struct Context<F: ScalarField> {
 
     // TODO: gates that use fixed columns as selectors?
     /// A [Vec] tracking equality constraints between pairs of [Context] `advice` cells.
-    /// 
+    ///
     /// Assumes both `advice` cells are in the same [Context].
     pub advice_equality_constraints: Vec<(ContextCell, ContextCell)>,
 
     /// A [Vec] tracking pairs equality constraints between Fixed values and [Context] `advice` cells.
-    /// 
+    ///
     /// Assumes the constant and `advice` cell are in the same [Context].
     pub constant_equality_constraints: Vec<(F, ContextCell)>,
 }
@@ -234,7 +235,7 @@ impl<F: ScalarField> Context<F> {
     /// Returns the [AssignedValue] of the cell at the given `offset` in the `advice` column of [Context]
     /// * `offset`: the offset of the cell to be fetched
     ///     * `offset` may be negative indexing from the end of the column (e.g., `-1` is the last cell)
-    /// * Assumes `offset` is a valid index in `advice`; 
+    /// * Assumes `offset` is a valid index in `advice`;
     ///     * `0` <= `offset` < `advice.len()` (or `advice.len() + offset >= 0` if `offset` is negative)
     pub fn get(&self, offset: isize) -> AssignedValue<F> {
         let offset = if offset < 0 {
@@ -259,7 +260,7 @@ impl<F: ScalarField> Context<F> {
     }
 
     /// Pushes multiple advice cells to the `advice` column of [Context] and enables them by enabling the corresponding selector specified in `gate_offset`.
-    /// 
+    ///
     /// * `inputs`: Iterator that specifies the cells to be assigned
     /// * `gate_offsets`: specifies relative offset from current position to enable selector for the gate (e.g., `0` is inputs[0]).
     ///     * `offset` may be negative indexing from the end of the column (e.g., `-1` is the last previously assigned cell)
@@ -293,7 +294,7 @@ impl<F: ScalarField> Context<F> {
     /// Pushes multiple advice cells to the `advice` column of [Context] and enables them by enabling the corresponding selector specified in `gate_offset` and returns the last assigned cell.
     ///
     /// Assumes `gate_offsets` is the same length as `inputs`
-    /// 
+    ///
     /// Returns the last assigned cell
     /// * `inputs`: Iterator that specifies the cells to be assigned
     /// * `gate_offsets`: specifies indices to enable selector for the gate; assume `gate_offsets` is sorted in increasing order
@@ -311,9 +312,9 @@ impl<F: ScalarField> Context<F> {
     }
 
     /// Pushes multiple advice cells to the `advice` column of [Context] and enables them by enabling the corresponding selector specified in `gate_offset`.
-    /// 
-    /// Allows for the specification of equality constraints between cells at `equality_offsets` within the `advice` column and external advice cells specified in `external_equality` (e.g, Fixed column). 
-    /// * `gate_offsets`: specifies indices to enable selector for the gate; 
+    ///
+    /// Allows for the specification of equality constraints between cells at `equality_offsets` within the `advice` column and external advice cells specified in `external_equality` (e.g, Fixed column).
+    /// * `gate_offsets`: specifies indices to enable selector for the gate;
     ///     * `offset` may be negative indexing from the end of the column (e.g., `-1` is the last cell)
     /// * `equality_offsets`: specifies pairs of indices to constrain equality
     /// * `external_equality`: specifies an existing cell to constrain equality with the cell at a certain index


### PR DESCRIPTION
Make `RangeCircuitBuilder` and `RangeWithInstanceCircuitBuilder` automatically detect whether to create and load a lookup table or not (for range checks). 

This way we no longer need to decide whether to use `GateCircuitBuilder` or `RangeCircuitBuilder` (the former is kept for compatibility for now).