### PR TITLE
Use new types to validate input assumptions

### DIFF
--- a/halo2-base/src/utils.rs
+++ b/halo2-base/src/utils.rs
@@ -13,7 +13,10 @@ use num_traits::{One, Zero};
 pub trait BigPrimeField: ScalarField {
     /// Converts a slice of [u64] to [BigPrimeField]
     /// * `val`: the slice of u64
-    /// Assumes val.len() <= 4
+    ///
+    /// # Assumptions
+    /// * `val` has the correct length for the implementation
+    /// * The integer value of `val` is already less than the modulus of `Self`
     fn from_u64_digits(val: &[u64]) -> Self;
 }
 #[cfg(feature = "halo2-axiom")]
@@ -139,6 +142,9 @@ pub fn power_of_two<F: BigPrimeField>(n: usize) -> F {
 
 /// Converts an immutable reference to [BigUint] to a [BigPrimeField].
 /// * `e`: immutable reference to [BigUint]
+///
+/// # Assumptions:
+/// * `e` is less than the modulus of `F`
 pub fn biguint_to_fe<F: BigPrimeField>(e: &BigUint) -> F {
     #[cfg(feature = "halo2-axiom")]
     {
@@ -154,6 +160,9 @@ pub fn biguint_to_fe<F: BigPrimeField>(e: &BigUint) -> F {
 
 /// Converts an immutable reference to [BigInt] to a [BigPrimeField].
 /// * `e`: immutable reference to [BigInt]
+///
+/// # Assumptions:
+/// * The absolute value of `e` is less than the modulus of `F`
 pub fn bigint_to_fe<F: BigPrimeField>(e: &BigInt) -> F {
     #[cfg(feature = "halo2-axiom")]
     {
@@ -240,6 +249,8 @@ pub fn decompose_fe_to_u64_limbs<F: ScalarField>(
 /// * `e`: immutable reference to [BigInt] to decompose
 /// * `num_limbs`: number of limbs to decompose `e` into
 /// * `bit_len`: number of bits in each limb
+///
+/// Truncates to `num_limbs` limbs if `e` is too large.
 pub fn decompose_biguint<F: BigPrimeField>(
     e: &BigUint,
     num_limbs: usize,

--- a/halo2-ecc/benches/fp_mul.rs
+++ b/halo2-ecc/benches/fp_mul.rs
@@ -44,7 +44,7 @@ fn fp_mul_bench<F: PrimeField>(
     let range = RangeChip::<F>::default(lookup_bits);
     let chip = FpChip::<F, Fq>::new(&range, limb_bits, num_limbs);
 
-    let [a, b] = [_a, _b].map(|x| chip.load_private(ctx, FpChip::<F, Fq>::fe_to_witness(&x)));
+    let [a, b] = [_a, _b].map(|x| chip.load_private(ctx, x));
     for _ in 0..2857 {
         chip.mul(ctx, &a, &b);
     }

--- a/halo2-ecc/benches/msm.rs
+++ b/halo2-ecc/benches/msm.rs
@@ -59,8 +59,10 @@ fn msm_bench(
     let ctx = builder.main(0);
     let scalars_assigned =
         scalars.iter().map(|scalar| vec![ctx.load_witness(*scalar)]).collect::<Vec<_>>();
-    let bases_assigned =
-        bases.iter().map(|base| ecc_chip.load_private(ctx, (base.x, base.y))).collect::<Vec<_>>();
+    let bases_assigned = bases
+        .iter()
+        .map(|base| ecc_chip.load_private_unchecked(ctx, (base.x, base.y)))
+        .collect::<Vec<_>>();
 
     ecc_chip.variable_base_msm_in::<G1Affine>(
         builder,

--- a/halo2-ecc/src/bigint/add_no_carry.rs
+++ b/halo2-ecc/src/bigint/add_no_carry.rs
@@ -8,17 +8,17 @@ use std::cmp::max;
 pub fn assign<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: OverflowInteger<F>,
+    b: OverflowInteger<F>,
 ) -> OverflowInteger<F> {
     let out_limbs = a
         .limbs
-        .iter()
-        .zip_eq(b.limbs.iter())
-        .map(|(&a_limb, &b_limb)| gate.add(ctx, a_limb, b_limb))
+        .into_iter()
+        .zip_eq(b.limbs)
+        .map(|(a_limb, b_limb)| gate.add(ctx, a_limb, b_limb))
         .collect();
 
-    OverflowInteger::construct(out_limbs, max(a.max_limb_bits, b.max_limb_bits) + 1)
+    OverflowInteger::new(out_limbs, max(a.max_limb_bits, b.max_limb_bits) + 1)
 }
 
 /// # Assumptions
@@ -27,11 +27,11 @@ pub fn assign<F: ScalarField>(
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
+    a: CRTInteger<F>,
+    b: CRTInteger<F>,
 ) -> CRTInteger<F> {
-    let out_trunc = assign::<F>(gate, ctx, &a.truncation, &b.truncation);
+    let out_trunc = assign(gate, ctx, a.truncation, b.truncation);
     let out_native = gate.add(ctx, a.native, b.native);
-    let out_val = &a.value + &b.value;
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    let out_val = a.value + b.value;
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/big_is_equal.rs
+++ b/halo2-ecc/src/bigint/big_is_equal.rs
@@ -1,8 +1,8 @@
-use super::{CRTInteger, OverflowInteger};
+use super::ProperUint;
 use halo2_base::{gates::GateInstructions, utils::ScalarField, AssignedValue, Context};
 use itertools::Itertools;
 
-/// Given OverflowInteger<F>'s `a` and `b` of the same shape,
+/// Given [`ProperUint`]s `a` and `b` with the same number of limbs,
 /// returns whether `a == b`.
 ///
 /// # Assumptions:
@@ -11,38 +11,19 @@ use itertools::Itertools;
 pub fn assign<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: impl Into<ProperUint<F>>,
+    b: impl Into<ProperUint<F>>,
 ) -> AssignedValue<F> {
-    debug_assert!(!a.limbs.is_empty());
+    let a = a.into();
+    let b = b.into();
+    debug_assert!(!a.0.is_empty());
 
-    let mut a_limbs = a.limbs.iter();
-    let mut b_limbs = b.limbs.iter();
-    let mut partial = gate.is_equal(ctx, *a_limbs.next().unwrap(), *b_limbs.next().unwrap());
-    for (&a_limb, &b_limb) in a_limbs.zip_eq(b_limbs) {
+    let mut a_limbs = a.0.into_iter();
+    let mut b_limbs = b.0.into_iter();
+    let mut partial = gate.is_equal(ctx, a_limbs.next().unwrap(), b_limbs.next().unwrap());
+    for (a_limb, b_limb) in a_limbs.zip_eq(b_limbs) {
         let eq_limb = gate.is_equal(ctx, a_limb, b_limb);
         partial = gate.and(ctx, eq_limb, partial);
     }
     partial
-}
-
-pub fn wrapper<F: ScalarField>(
-    gate: &impl GateInstructions<F>,
-    ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
-) -> AssignedValue<F> {
-    assign(gate, ctx, &a.truncation, &b.truncation)
-}
-
-pub fn crt<F: ScalarField>(
-    gate: &impl GateInstructions<F>,
-    ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
-) -> AssignedValue<F> {
-    debug_assert_eq!(a.value, b.value);
-    let out_trunc = assign::<F>(gate, ctx, &a.truncation, &b.truncation);
-    let out_native = gate.is_equal(ctx, a.native, b.native);
-    gate.and(ctx, out_trunc, out_native)
 }

--- a/halo2-ecc/src/bigint/big_less_than.rs
+++ b/halo2-ecc/src/bigint/big_less_than.rs
@@ -1,4 +1,4 @@
-use super::OverflowInteger;
+use super::ProperUint;
 use halo2_base::{gates::RangeInstructions, utils::ScalarField, AssignedValue, Context};
 
 // given OverflowInteger<F>'s `a` and `b` of the same shape,
@@ -6,8 +6,8 @@ use halo2_base::{gates::RangeInstructions, utils::ScalarField, AssignedValue, Co
 pub fn assign<F: ScalarField>(
     range: &impl RangeInstructions<F>,
     ctx: &mut Context<F>,
-    a: OverflowInteger<F>,
-    b: OverflowInteger<F>,
+    a: impl Into<ProperUint<F>>,
+    b: impl Into<ProperUint<F>>,
     limb_bits: usize,
     limb_base: F,
 ) -> AssignedValue<F> {

--- a/halo2-ecc/src/bigint/big_less_than.rs
+++ b/halo2-ecc/src/bigint/big_less_than.rs
@@ -6,12 +6,12 @@ use halo2_base::{gates::RangeInstructions, utils::ScalarField, AssignedValue, Co
 pub fn assign<F: ScalarField>(
     range: &impl RangeInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: OverflowInteger<F>,
+    b: OverflowInteger<F>,
     limb_bits: usize,
     limb_base: F,
 ) -> AssignedValue<F> {
     // a < b iff a - b has underflow
-    let (_, underflow) = super::sub::assign::<F>(range, ctx, a, b, limb_bits, limb_base);
+    let (_, underflow) = super::sub::assign(range, ctx, a, b, limb_bits, limb_base);
     underflow
 }

--- a/halo2-ecc/src/bigint/mod.rs
+++ b/halo2-ecc/src/bigint/mod.rs
@@ -205,13 +205,6 @@ pub struct FixedCRTInteger<F: ScalarField> {
     pub value: BigUint,
 }
 
-#[derive(Clone, Debug)]
-pub struct FixedAssignedCRTInteger<F: ScalarField> {
-    pub truncation: FixedOverflowInteger<F>,
-    pub limb_fixed_cells: Vec<Cell>,
-    pub value: BigUint,
-}
-
 impl<F: BigPrimeField> FixedCRTInteger<F> {
     pub fn construct(truncation: FixedOverflowInteger<F>, value: BigUint) -> Self {
         Self { truncation, value }

--- a/halo2-ecc/src/bigint/mod.rs
+++ b/halo2-ecc/src/bigint/mod.rs
@@ -137,9 +137,9 @@ impl<F: BigPrimeField> FixedOverflowInteger<F> {
             .fold(BigUint::zero(), |acc, x| (acc << limb_bits) + fe_to_biguint(x))
     }
 
-    pub fn assign(self, ctx: &mut Context<F>, limb_bits: usize) -> OverflowInteger<F> {
+    pub fn assign(self, ctx: &mut Context<F>) -> ProperUint<F> {
         let assigned_limbs = self.limbs.into_iter().map(|limb| ctx.load_constant(limb)).collect();
-        OverflowInteger::new(assigned_limbs, limb_bits)
+        ProperUint(assigned_limbs)
     }
 
     /// only use case is when coeffs has only a single 1, rest are 0
@@ -299,7 +299,7 @@ impl<F: BigPrimeField> FixedCRTInteger<F> {
         limb_bits: usize,
         native_modulus: &BigUint,
     ) -> ProperCrtUint<F> {
-        let assigned_truncation = self.truncation.assign(ctx, limb_bits);
+        let assigned_truncation = self.truncation.assign(ctx).into_overflow(limb_bits);
         let assigned_native = ctx.load_constant(biguint_to_fe(&(&self.value % native_modulus)));
         ProperCrtUint(CRTInteger::new(assigned_truncation, assigned_native, self.value.into()))
     }

--- a/halo2-ecc/src/bigint/mul_no_carry.rs
+++ b/halo2-ecc/src/bigint/mul_no_carry.rs
@@ -9,8 +9,8 @@ use halo2_base::{gates::GateInstructions, utils::ScalarField, Context, QuantumCe
 pub fn truncate<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: OverflowInteger<F>,
+    b: OverflowInteger<F>,
     num_limbs_log2_ceil: usize,
 ) -> OverflowInteger<F> {
     let k = a.limbs.len();
@@ -31,19 +31,19 @@ pub fn truncate<F: ScalarField>(
         })
         .collect();
 
-    OverflowInteger::construct(out_limbs, num_limbs_log2_ceil + a.max_limb_bits + b.max_limb_bits)
+    OverflowInteger::new(out_limbs, num_limbs_log2_ceil + a.max_limb_bits + b.max_limb_bits)
 }
 
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
+    a: CRTInteger<F>,
+    b: CRTInteger<F>,
     num_limbs_log2_ceil: usize,
 ) -> CRTInteger<F> {
-    let out_trunc = truncate::<F>(gate, ctx, &a.truncation, &b.truncation, num_limbs_log2_ceil);
+    let out_trunc = truncate::<F>(gate, ctx, a.truncation, b.truncation, num_limbs_log2_ceil);
     let out_native = gate.mul(ctx, a.native, b.native);
-    let out_val = &a.value * &b.value;
+    let out_val = a.value * b.value;
 
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/negative.rs
+++ b/halo2-ecc/src/bigint/negative.rs
@@ -7,5 +7,5 @@ pub fn assign<F: ScalarField>(
     a: OverflowInteger<F>,
 ) -> OverflowInteger<F> {
     let out_limbs = a.limbs.into_iter().map(|limb| gate.neg(ctx, limb)).collect();
-    OverflowInteger::construct(out_limbs, a.max_limb_bits)
+    OverflowInteger::new(out_limbs, a.max_limb_bits)
 }

--- a/halo2-ecc/src/bigint/scalar_mul_and_add_no_carry.rs
+++ b/halo2-ecc/src/bigint/scalar_mul_and_add_no_carry.rs
@@ -18,27 +18,27 @@ use std::cmp::max;
 pub fn assign<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: OverflowInteger<F>,
+    b: OverflowInteger<F>,
     c_f: F,
     c_log2_ceil: usize,
 ) -> OverflowInteger<F> {
     let out_limbs = a
         .limbs
-        .iter()
-        .zip_eq(b.limbs.iter())
-        .map(|(&a_limb, &b_limb)| gate.mul_add(ctx, a_limb, Constant(c_f), b_limb))
+        .into_iter()
+        .zip_eq(b.limbs)
+        .map(|(a_limb, b_limb)| gate.mul_add(ctx, a_limb, Constant(c_f), b_limb))
         .collect();
 
-    OverflowInteger::construct(out_limbs, max(a.max_limb_bits + c_log2_ceil, b.max_limb_bits) + 1)
+    OverflowInteger::new(out_limbs, max(a.max_limb_bits + c_log2_ceil, b.max_limb_bits) + 1)
 }
 
 /// compute a * c + b = b + a * c
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
+    a: CRTInteger<F>,
+    b: CRTInteger<F>,
     c: i64,
 ) -> CRTInteger<F> {
     debug_assert_eq!(a.truncation.limbs.len(), b.truncation.limbs.len());
@@ -51,8 +51,8 @@ pub fn crt<F: ScalarField>(
         (-F::from(c_abs), c_abs)
     };
 
-    let out_trunc = assign::<F>(gate, ctx, &a.truncation, &b.truncation, c_f, log2_ceil(c_abs));
+    let out_trunc = assign(gate, ctx, a.truncation, b.truncation, c_f, log2_ceil(c_abs));
     let out_native = gate.mul_add(ctx, a.native, Constant(c_f), b.native);
-    let out_val = &a.value * c + &b.value;
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    let out_val = a.value * c + b.value;
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/scalar_mul_no_carry.rs
+++ b/halo2-ecc/src/bigint/scalar_mul_no_carry.rs
@@ -14,13 +14,13 @@ pub fn assign<F: ScalarField>(
     c_log2_ceil: usize,
 ) -> OverflowInteger<F> {
     let out_limbs = a.limbs.into_iter().map(|limb| gate.mul(ctx, limb, Constant(c_f))).collect();
-    OverflowInteger::construct(out_limbs, a.max_limb_bits + c_log2_ceil)
+    OverflowInteger::new(out_limbs, a.max_limb_bits + c_log2_ceil)
 }
 
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
+    a: CRTInteger<F>,
     c: i64,
 ) -> CRTInteger<F> {
     let (c_f, c_abs) = if c >= 0 {
@@ -31,15 +31,9 @@ pub fn crt<F: ScalarField>(
         (-F::from(c_abs), c_abs)
     };
 
-    let out_limbs =
-        a.truncation.limbs.iter().map(|limb| gate.mul(ctx, *limb, Constant(c_f))).collect();
-
+    let out_overflow = assign(gate, ctx, a.truncation, c_f, log2_ceil(c_abs));
     let out_native = gate.mul(ctx, a.native, Constant(c_f));
-    let out_val = &a.value * c;
+    let out_val = a.value * c;
 
-    CRTInteger::construct(
-        OverflowInteger::construct(out_limbs, a.truncation.max_limb_bits + log2_ceil(c_abs)),
-        out_native,
-        out_val,
-    )
+    CRTInteger::new(out_overflow, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/select.rs
+++ b/halo2-ecc/src/bigint/select.rs
@@ -20,31 +20,31 @@ pub fn assign<F: ScalarField>(
         .map(|(a_limb, b_limb)| gate.select(ctx, a_limb, b_limb, sel))
         .collect();
 
-    OverflowInteger::construct(out_limbs, max(a.max_limb_bits, b.max_limb_bits))
+    OverflowInteger::new(out_limbs, max(a.max_limb_bits, b.max_limb_bits))
 }
 
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
+    a: CRTInteger<F>,
+    b: CRTInteger<F>,
     sel: AssignedValue<F>,
 ) -> CRTInteger<F> {
     debug_assert_eq!(a.truncation.limbs.len(), b.truncation.limbs.len());
     let out_limbs = a
         .truncation
         .limbs
-        .iter()
-        .zip(b.truncation.limbs.iter())
-        .map(|(&a_limb, &b_limb)| gate.select(ctx, a_limb, b_limb, sel))
+        .into_iter()
+        .zip_eq(b.truncation.limbs)
+        .map(|(a_limb, b_limb)| gate.select(ctx, a_limb, b_limb, sel))
         .collect();
 
-    let out_trunc = OverflowInteger::construct(
+    let out_trunc = OverflowInteger::new(
         out_limbs,
         max(a.truncation.max_limb_bits, b.truncation.max_limb_bits),
     );
 
     let out_native = gate.select(ctx, a.native, b.native, sel);
-    let out_val = if sel.value().is_zero_vartime() { b.value.clone() } else { a.value.clone() };
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    let out_val = if sel.value().is_zero_vartime() { b.value } else { a.value };
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/select_by_indicator.rs
+++ b/halo2-ecc/src/bigint/select_by_indicator.rs
@@ -22,48 +22,48 @@ pub fn assign<F: ScalarField>(
 
     let max_limb_bits = a.iter().fold(0, |acc, x| max(acc, x.max_limb_bits));
 
-    OverflowInteger::construct(out_limbs, max_limb_bits)
+    OverflowInteger::new(out_limbs, max_limb_bits)
 }
 
 /// only use case is when coeffs has only a single 1, rest are 0
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &[CRTInteger<F>],
+    a: &[impl AsRef<CRTInteger<F>>],
     coeffs: &[AssignedValue<F>],
     limb_bases: &[F],
 ) -> CRTInteger<F> {
     assert_eq!(a.len(), coeffs.len());
-    let k = a[0].truncation.limbs.len();
+    let k = a[0].as_ref().truncation.limbs.len();
 
     let out_limbs = (0..k)
         .map(|idx| {
-            let int_limbs = a.iter().map(|a| a.truncation.limbs[idx]);
+            let int_limbs = a.iter().map(|a| a.as_ref().truncation.limbs[idx]);
             gate.select_by_indicator(ctx, int_limbs, coeffs.iter().copied())
         })
         .collect();
 
-    let max_limb_bits = a.iter().fold(0, |acc, x| max(acc, x.truncation.max_limb_bits));
+    let max_limb_bits = a.iter().fold(0, |acc, x| max(acc, x.as_ref().truncation.max_limb_bits));
 
-    let out_trunc = OverflowInteger::construct(out_limbs, max_limb_bits);
+    let out_trunc = OverflowInteger::new(out_limbs, max_limb_bits);
     let out_native = if a.len() > k {
-        OverflowInteger::<F>::evaluate(
-            gate,
+        OverflowInteger::evaluate_native(
             ctx,
+            gate,
             out_trunc.limbs.iter().copied(),
-            limb_bases[..k].iter().copied(),
+            &limb_bases[..k],
         )
     } else {
-        let a_native = a.iter().map(|x| x.native);
+        let a_native = a.iter().map(|x| x.as_ref().native);
         gate.select_by_indicator(ctx, a_native, coeffs.iter().copied())
     };
     let out_val = a.iter().zip(coeffs.iter()).fold(BigInt::zero(), |acc, (x, y)| {
         if y.value().is_zero_vartime() {
             acc
         } else {
-            x.value.clone()
+            x.as_ref().value.clone()
         }
     });
 
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bigint/sub_no_carry.rs
+++ b/halo2-ecc/src/bigint/sub_no_carry.rs
@@ -8,27 +8,27 @@ use std::cmp::max;
 pub fn assign<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &OverflowInteger<F>,
-    b: &OverflowInteger<F>,
+    a: OverflowInteger<F>,
+    b: OverflowInteger<F>,
 ) -> OverflowInteger<F> {
     let out_limbs = a
         .limbs
-        .iter()
-        .zip_eq(b.limbs.iter())
-        .map(|(&a_limb, &b_limb)| gate.sub(ctx, a_limb, b_limb))
+        .into_iter()
+        .zip_eq(b.limbs)
+        .map(|(a_limb, b_limb)| gate.sub(ctx, a_limb, b_limb))
         .collect();
 
-    OverflowInteger::construct(out_limbs, max(a.max_limb_bits, b.max_limb_bits) + 1)
+    OverflowInteger::new(out_limbs, max(a.max_limb_bits, b.max_limb_bits) + 1)
 }
 
 pub fn crt<F: ScalarField>(
     gate: &impl GateInstructions<F>,
     ctx: &mut Context<F>,
-    a: &CRTInteger<F>,
-    b: &CRTInteger<F>,
+    a: CRTInteger<F>,
+    b: CRTInteger<F>,
 ) -> CRTInteger<F> {
-    let out_trunc = assign::<F>(gate, ctx, &a.truncation, &b.truncation);
+    let out_trunc = assign(gate, ctx, a.truncation, b.truncation);
     let out_native = gate.sub(ctx, a.native, b.native);
-    let out_val = &a.value - &b.value;
-    CRTInteger::construct(out_trunc, out_native, out_val)
+    let out_val = a.value - b.value;
+    CRTInteger::new(out_trunc, out_native, out_val)
 }

--- a/halo2-ecc/src/bn254/mod.rs
+++ b/halo2-ecc/src/bn254/mod.rs
@@ -1,15 +1,14 @@
+use crate::bigint::ProperCrtUint;
+use crate::fields::vector::FieldVector;
+use crate::fields::{fp, fp12, fp2};
 use crate::halo2_proofs::halo2curves::bn256::{Fq, Fq12, Fq2};
-use crate::{
-    bigint::CRTInteger,
-    fields::{fp, fp12, fp2, FieldExtPoint},
-};
 
 pub mod final_exp;
 pub mod pairing;
 
 pub type FpChip<'range, F> = fp::FpChip<'range, F, Fq>;
-pub type FpPoint<F> = CRTInteger<F>;
-pub type FqPoint<F> = FieldExtPoint<FpPoint<F>>;
+pub type FpPoint<F> = ProperCrtUint<F>;
+pub type FqPoint<F> = FieldVector<FpPoint<F>>;
 pub type Fp2Chip<'chip, F> = fp2::Fp2Chip<'chip, F, FpChip<'chip, F>, Fq2>;
 pub type Fp12Chip<'chip, F> = fp12::Fp12Chip<'chip, F, FpChip<'chip, F>, Fq12, 9>;
 

--- a/halo2-ecc/src/bn254/tests/ec_add.rs
+++ b/halo2-ecc/src/bn254/tests/ec_add.rs
@@ -33,13 +33,14 @@ fn g2_add_test<F: PrimeField>(ctx: &mut Context<F>, params: CircuitParams, _poin
     let fp2_chip = Fp2Chip::<F>::new(&fp_chip);
     let g2_chip = EccChip::new(&fp2_chip);
 
-    let points = _points.iter().map(|pt| g2_chip.assign_point(ctx, *pt)).collect::<Vec<_>>();
+    let points =
+        _points.iter().map(|pt| g2_chip.assign_point_unchecked(ctx, *pt)).collect::<Vec<_>>();
 
-    let acc = g2_chip.sum::<G2Affine>(ctx, points.iter());
+    let acc = g2_chip.sum::<G2Affine>(ctx, points);
 
     let answer = _points.iter().fold(G2Affine::identity(), |a, b| (a + b).to_affine());
-    let x = fp2_chip.get_assigned_value(&acc.x);
-    let y = fp2_chip.get_assigned_value(&acc.y);
+    let x = fp2_chip.get_assigned_value(&acc.x.into());
+    let y = fp2_chip.get_assigned_value(&acc.y.into());
     assert_eq!(answer.x, x);
     assert_eq!(answer.y, y);
 }

--- a/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
+++ b/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
@@ -3,8 +3,6 @@ use std::{
     io::{BufRead, BufReader},
 };
 
-#[allow(unused_imports)]
-use crate::ecc::fixed_base::FixedEcPoint;
 use crate::fields::{FpStrategy, PrimeField};
 
 use super::*;
@@ -62,10 +60,10 @@ fn fixed_base_msm_test(
     }
     let msm_answer = elts.into_iter().reduce(|a, b| a + b).unwrap().to_affine();
 
-    let msm_x = msm.x.value;
-    let msm_y = msm.y.value;
-    assert_eq!(msm_x, fe_to_biguint(&msm_answer.x).into());
-    assert_eq!(msm_y, fe_to_biguint(&msm_answer.y).into());
+    let msm_x = msm.x.value();
+    let msm_y = msm.y.value();
+    assert_eq!(msm_x, fe_to_biguint(&msm_answer.x));
+    assert_eq!(msm_y, fe_to_biguint(&msm_answer.y));
 }
 
 fn random_fixed_base_msm_circuit(

--- a/halo2-ecc/src/bn254/tests/msm.rs
+++ b/halo2-ecc/src/bn254/tests/msm.rs
@@ -47,8 +47,10 @@ fn msm_test(
     let ctx = builder.main(0);
     let scalars_assigned =
         scalars.iter().map(|scalar| vec![ctx.load_witness(*scalar)]).collect::<Vec<_>>();
-    let bases_assigned =
-        bases.iter().map(|base| ecc_chip.load_private(ctx, (base.x, base.y))).collect::<Vec<_>>();
+    let bases_assigned = bases
+        .iter()
+        .map(|base| ecc_chip.load_private_unchecked(ctx, (base.x, base.y)))
+        .collect::<Vec<_>>();
 
     let msm = ecc_chip.variable_base_msm_in::<G1Affine>(
         builder,
@@ -67,10 +69,10 @@ fn msm_test(
         .unwrap()
         .to_affine();
 
-    let msm_x = msm.x.value;
-    let msm_y = msm.y.value;
-    assert_eq!(msm_x, fe_to_biguint(&msm_answer.x).into());
-    assert_eq!(msm_y, fe_to_biguint(&msm_answer.y).into());
+    let msm_x = msm.x.value();
+    let msm_y = msm.y.value();
+    assert_eq!(msm_x, fe_to_biguint(&msm_answer.x));
+    assert_eq!(msm_y, fe_to_biguint(&msm_answer.y));
 }
 
 fn random_msm_circuit(

--- a/halo2-ecc/src/bn254/tests/pairing.rs
+++ b/halo2-ecc/src/bn254/tests/pairing.rs
@@ -43,8 +43,8 @@ fn pairing_test<F: PrimeField>(
     let fp_chip = FpChip::<F>::new(&range, params.limb_bits, params.num_limbs);
     let chip = PairingChip::new(&fp_chip);
 
-    let P_assigned = chip.load_private_g1(ctx, P);
-    let Q_assigned = chip.load_private_g2(ctx, Q);
+    let P_assigned = chip.load_private_g1_unchecked(ctx, P);
+    let Q_assigned = chip.load_private_g2_unchecked(ctx, Q);
 
     // test optimal ate pairing
     let f = chip.pairing(ctx, &Q_assigned, &P_assigned);
@@ -52,7 +52,10 @@ fn pairing_test<F: PrimeField>(
     let actual_f = pairing(&P, &Q);
     let fp12_chip = Fp12Chip::new(&fp_chip);
     // cannot directly compare f and actual_f because `Gt` has private field `Fq12`
-    assert_eq!(format!("Gt({:?})", fp12_chip.get_assigned_value(&f)), format!("{actual_f:?}"));
+    assert_eq!(
+        format!("Gt({:?})", fp12_chip.get_assigned_value(&f.into())),
+        format!("{actual_f:?}")
+    );
 }
 
 fn random_pairing_circuit(

--- a/halo2-ecc/src/ecc/ecdsa.rs
+++ b/halo2-ecc/src/ecc/ecdsa.rs
@@ -31,7 +31,7 @@ where
         FpChip::<F, SF>::new(base_chip.range, base_chip.limb_bits, base_chip.num_limbs);
     let n = scalar_chip.p.to_biguint().unwrap();
     let n = FixedOverflowInteger::from_native(&n, scalar_chip.num_limbs, scalar_chip.limb_bits);
-    let n = n.assign(ctx, base_chip.limb_bits);
+    let n = n.assign(ctx);
 
     // check r,s are in [1, n - 1]
     let r_valid = scalar_chip.is_soft_nonzero(ctx, &r);
@@ -81,7 +81,7 @@ where
     let u1_small = big_less_than::assign(
         base_chip.range(),
         ctx,
-        u1.0.truncation,
+        u1,
         n.clone(),
         base_chip.limb_bits,
         base_chip.limb_bases[1],
@@ -89,7 +89,7 @@ where
     let u2_small = big_less_than::assign(
         base_chip.range(),
         ctx,
-        u2.0.truncation,
+        u2,
         n,
         base_chip.limb_bits,
         base_chip.limb_bases[1],

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -920,14 +920,13 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
         self.field_chip.assert_equal(ctx, P.y, Q.y);
     }
 
-    pub fn sum<'b, 'v: 'b, C>(
+    pub fn sum<C>(
         &self,
         ctx: &mut Context<F>,
         points: impl IntoIterator<Item = EcPoint<F, FC::FieldPoint>>,
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt<Base = FC::FieldType>,
-        FC::FieldPoint: 'b,
     {
         let rand_point = self.load_random_point::<C>(ctx);
         let rand_point = into_strict_point(self.field_chip, ctx, rand_point);

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -1,6 +1,5 @@
 #![allow(non_snake_case)]
-use crate::bigint::CRTInteger;
-use crate::fields::{fp::FpChip, FieldChip, PrimeField, PrimeFieldChip, Selectable};
+use crate::fields::{fp::FpChip, FieldChip, PrimeField, Selectable};
 use crate::halo2_proofs::arithmetic::CurveAffine;
 use group::{Curve, Group};
 use halo2_base::gates::builder::GateThreadBuilder;
@@ -33,8 +32,17 @@ impl<F: PrimeField, FieldPoint: Clone> Clone for EcPoint<F, FieldPoint> {
     }
 }
 
+// Improve readability by allowing `&EcPoint` to be converted to `EcPoint` via cloning
+impl<'a, F: PrimeField, FieldPoint: Clone> From<&'a EcPoint<F, FieldPoint>>
+    for EcPoint<F, FieldPoint>
+{
+    fn from(value: &'a EcPoint<F, FieldPoint>) -> Self {
+        value.clone()
+    }
+}
+
 impl<F: PrimeField, FieldPoint> EcPoint<F, FieldPoint> {
-    pub fn construct(x: FieldPoint, y: FieldPoint) -> Self {
+    pub fn new(x: FieldPoint, y: FieldPoint) -> Self {
         Self { x, y, _marker: PhantomData }
     }
 
@@ -44,6 +52,83 @@ impl<F: PrimeField, FieldPoint> EcPoint<F, FieldPoint> {
 
     pub fn y(&self) -> &FieldPoint {
         &self.y
+    }
+}
+
+/// An elliptic curve point where it is easy to compare the x-coordinate of two points
+#[derive(Clone, Debug)]
+pub struct StrictEcPoint<F: PrimeField, FC: FieldChip<F>> {
+    pub x: FC::ReducedFieldPoint,
+    pub y: FC::FieldPoint,
+    _marker: PhantomData<F>,
+}
+
+impl<F: PrimeField, FC: FieldChip<F>> StrictEcPoint<F, FC> {
+    pub fn new(x: FC::ReducedFieldPoint, y: FC::FieldPoint) -> Self {
+        Self { x, y, _marker: PhantomData }
+    }
+}
+
+impl<F: PrimeField, FC: FieldChip<F>> From<StrictEcPoint<F, FC>> for EcPoint<F, FC::FieldPoint> {
+    fn from(value: StrictEcPoint<F, FC>) -> Self {
+        Self::new(value.x.into(), value.y)
+    }
+}
+
+impl<'a, F: PrimeField, FC: FieldChip<F>> From<&'a StrictEcPoint<F, FC>>
+    for EcPoint<F, FC::FieldPoint>
+{
+    fn from(value: &'a StrictEcPoint<F, FC>) -> Self {
+        value.clone().into()
+    }
+}
+
+/// An elliptic curve point where the x-coordinate has already been constrained to be reduced or not.
+/// In the reduced case one can more optimally compare equality of x-coordinates.
+#[derive(Clone, Debug)]
+pub enum ComparableEcPoint<F: PrimeField, FC: FieldChip<F>> {
+    Strict(StrictEcPoint<F, FC>),
+    NonStrict(EcPoint<F, FC::FieldPoint>),
+}
+
+impl<F: PrimeField, FC: FieldChip<F>> From<StrictEcPoint<F, FC>> for ComparableEcPoint<F, FC> {
+    fn from(pt: StrictEcPoint<F, FC>) -> Self {
+        Self::Strict(pt)
+    }
+}
+
+impl<F: PrimeField, FC: FieldChip<F>> From<EcPoint<F, FC::FieldPoint>>
+    for ComparableEcPoint<F, FC>
+{
+    fn from(pt: EcPoint<F, FC::FieldPoint>) -> Self {
+        Self::NonStrict(pt)
+    }
+}
+
+impl<'a, F: PrimeField, FC: FieldChip<F>> From<&'a StrictEcPoint<F, FC>>
+    for ComparableEcPoint<F, FC>
+{
+    fn from(pt: &'a StrictEcPoint<F, FC>) -> Self {
+        Self::Strict(pt.clone())
+    }
+}
+
+impl<'a, F: PrimeField, FC: FieldChip<F>> From<&'a EcPoint<F, FC::FieldPoint>>
+    for ComparableEcPoint<F, FC>
+{
+    fn from(pt: &'a EcPoint<F, FC::FieldPoint>) -> Self {
+        Self::NonStrict(pt.clone())
+    }
+}
+
+impl<F: PrimeField, FC: FieldChip<F>> From<ComparableEcPoint<F, FC>>
+    for EcPoint<F, FC::FieldPoint>
+{
+    fn from(pt: ComparableEcPoint<F, FC>) -> Self {
+        match pt {
+            ComparableEcPoint::Strict(pt) => Self::new(pt.x.into(), pt.y),
+            ComparableEcPoint::NonStrict(pt) => pt,
+        }
     }
 }
 
@@ -57,37 +142,58 @@ impl<F: PrimeField, FieldPoint> EcPoint<F, FieldPoint> {
 //  x_3 = lambda^2 - x_1 - x_2 (mod p)
 //  y_3 = lambda (x_1 - x_3) - y_1 mod p
 //
-/// For optimization reasons, we assume that if you are using this with `is_strict = true`, then you have already called `chip.enforce_less_than_p` on both `P.x` and `Q.x`
+/// If `is_strict = true`, then this function constrains that `P.x != Q.x`.
+/// If you are calling this with `is_strict = false`, you must ensure that `P.x != Q.x` by some external logic (such
+/// as a mathematical theorem).
 pub fn ec_add_unequal<F: PrimeField, FC: FieldChip<F>>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
-    Q: &EcPoint<F, FC::FieldPoint>,
+    P: impl Into<ComparableEcPoint<F, FC>>,
+    Q: impl Into<ComparableEcPoint<F, FC>>,
     is_strict: bool,
 ) -> EcPoint<F, FC::FieldPoint> {
-    if is_strict {
-        // constrains that P.x != Q.x
-        let x_is_equal = chip.is_equal_unenforced(ctx, &P.x, &Q.x);
-        chip.range().gate().assert_is_const(ctx, &x_is_equal, &F::zero());
-    }
+    let (P, Q) = check_points_are_unequal(chip, ctx, P, Q, is_strict);
 
     let dx = chip.sub_no_carry(ctx, &Q.x, &P.x);
-    let dy = chip.sub_no_carry(ctx, &Q.y, &P.y);
-    let lambda = chip.divide_unsafe(ctx, &dy, &dx);
+    let dy = chip.sub_no_carry(ctx, Q.y, &P.y);
+    let lambda = chip.divide_unsafe(ctx, dy, dx);
 
     //  x_3 = lambda^2 - x_1 - x_2 (mod p)
     let lambda_sq = chip.mul_no_carry(ctx, &lambda, &lambda);
-    let lambda_sq_minus_px = chip.sub_no_carry(ctx, &lambda_sq, &P.x);
-    let x_3_no_carry = chip.sub_no_carry(ctx, &lambda_sq_minus_px, &Q.x);
-    let x_3 = chip.carry_mod(ctx, &x_3_no_carry);
+    let lambda_sq_minus_px = chip.sub_no_carry(ctx, lambda_sq, &P.x);
+    let x_3_no_carry = chip.sub_no_carry(ctx, lambda_sq_minus_px, Q.x);
+    let x_3 = chip.carry_mod(ctx, x_3_no_carry);
 
     //  y_3 = lambda (x_1 - x_3) - y_1 mod p
-    let dx_13 = chip.sub_no_carry(ctx, &P.x, &x_3);
-    let lambda_dx_13 = chip.mul_no_carry(ctx, &lambda, &dx_13);
-    let y_3_no_carry = chip.sub_no_carry(ctx, &lambda_dx_13, &P.y);
-    let y_3 = chip.carry_mod(ctx, &y_3_no_carry);
+    let dx_13 = chip.sub_no_carry(ctx, P.x, &x_3);
+    let lambda_dx_13 = chip.mul_no_carry(ctx, lambda, dx_13);
+    let y_3_no_carry = chip.sub_no_carry(ctx, lambda_dx_13, P.y);
+    let y_3 = chip.carry_mod(ctx, y_3_no_carry);
 
-    EcPoint::construct(x_3, y_3)
+    EcPoint::new(x_3, y_3)
+}
+
+/// If `do_check = true`, then this function constrains that `P.x != Q.x`.
+/// Otherwise does nothing.
+fn check_points_are_unequal<F: PrimeField, FC: FieldChip<F>>(
+    chip: &FC,
+    ctx: &mut Context<F>,
+    P: impl Into<ComparableEcPoint<F, FC>>,
+    Q: impl Into<ComparableEcPoint<F, FC>>,
+    do_check: bool,
+) -> (EcPoint<F, FC::FieldPoint> /*P */, EcPoint<F, FC::FieldPoint> /*Q */) {
+    let P = P.into();
+    let Q = Q.into();
+    if do_check {
+        // constrains that P.x != Q.x
+        let [x1, x2] = [&P, &Q].map(|pt| match pt {
+            ComparableEcPoint::Strict(pt) => pt.x.clone(),
+            ComparableEcPoint::NonStrict(pt) => chip.enforce_less_than(ctx, pt.x.clone()),
+        });
+        let x_is_equal = chip.is_equal_unenforced(ctx, x1, x2);
+        chip.gate().assert_is_const(ctx, &x_is_equal, &F::zero());
+    }
+    (EcPoint::from(P), EcPoint::from(Q))
 }
 
 // Implements:
@@ -99,43 +205,41 @@ pub fn ec_add_unequal<F: PrimeField, FC: FieldChip<F>>(
 //  y_3 = lambda (x_1 - x_3) - y_1 mod p
 //  Assumes that P !=Q and Q != (P - Q)
 //
-/// For optimization reasons, we assume that if you are using this with `is_strict = true`, then you have already called `chip.enforce_less_than_p` on both `P.x` and `Q.x`
+/// If `is_strict = true`, then this function constrains that `P.x != Q.x`.
+/// If you are calling this with `is_strict = false`, you must ensure that `P.x != Q.x` by some external logic (such
+/// as a mathematical theorem).
 pub fn ec_sub_unequal<F: PrimeField, FC: FieldChip<F>>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
-    Q: &EcPoint<F, FC::FieldPoint>,
+    P: impl Into<ComparableEcPoint<F, FC>>,
+    Q: impl Into<ComparableEcPoint<F, FC>>,
     is_strict: bool,
 ) -> EcPoint<F, FC::FieldPoint> {
-    if is_strict {
-        // constrains that P.x != Q.x
-        let x_is_equal = chip.is_equal_unenforced(ctx, &P.x, &Q.x);
-        chip.range().gate().assert_is_const(ctx, &x_is_equal, &F::zero());
-    }
+    let (P, Q) = check_points_are_unequal(chip, ctx, P, Q, is_strict);
 
     let dx = chip.sub_no_carry(ctx, &Q.x, &P.x);
-    let dy = chip.add_no_carry(ctx, &Q.y, &P.y);
+    let dy = chip.add_no_carry(ctx, Q.y, &P.y);
 
     let lambda = chip.neg_divide_unsafe(ctx, &dy, &dx);
 
     // (x_2 - x_1) * lambda + y_2 + y_1 = 0 (mod p)
-    let lambda_dx = chip.mul_no_carry(ctx, &lambda, &dx);
-    let lambda_dx_plus_dy = chip.add_no_carry(ctx, &lambda_dx, &dy);
-    chip.check_carry_mod_to_zero(ctx, &lambda_dx_plus_dy);
+    let lambda_dx = chip.mul_no_carry(ctx, &lambda, dx);
+    let lambda_dx_plus_dy = chip.add_no_carry(ctx, lambda_dx, dy);
+    chip.check_carry_mod_to_zero(ctx, lambda_dx_plus_dy);
 
     //  x_3 = lambda^2 - x_1 - x_2 (mod p)
     let lambda_sq = chip.mul_no_carry(ctx, &lambda, &lambda);
-    let lambda_sq_minus_px = chip.sub_no_carry(ctx, &lambda_sq, &P.x);
-    let x_3_no_carry = chip.sub_no_carry(ctx, &lambda_sq_minus_px, &Q.x);
-    let x_3 = chip.carry_mod(ctx, &x_3_no_carry);
+    let lambda_sq_minus_px = chip.sub_no_carry(ctx, lambda_sq, &P.x);
+    let x_3_no_carry = chip.sub_no_carry(ctx, lambda_sq_minus_px, Q.x);
+    let x_3 = chip.carry_mod(ctx, x_3_no_carry);
 
     //  y_3 = lambda (x_1 - x_3) - y_1 mod p
-    let dx_13 = chip.sub_no_carry(ctx, &P.x, &x_3);
-    let lambda_dx_13 = chip.mul_no_carry(ctx, &lambda, &dx_13);
-    let y_3_no_carry = chip.sub_no_carry(ctx, &lambda_dx_13, &P.y);
-    let y_3 = chip.carry_mod(ctx, &y_3_no_carry);
+    let dx_13 = chip.sub_no_carry(ctx, P.x, &x_3);
+    let lambda_dx_13 = chip.mul_no_carry(ctx, lambda, dx_13);
+    let y_3_no_carry = chip.sub_no_carry(ctx, lambda_dx_13, P.y);
+    let y_3 = chip.carry_mod(ctx, y_3_no_carry);
 
-    EcPoint::construct(x_3, y_3)
+    EcPoint::new(x_3, y_3)
 }
 
 // Implements:
@@ -153,27 +257,28 @@ pub fn ec_sub_unequal<F: PrimeField, FC: FieldChip<F>>(
 pub fn ec_double<F: PrimeField, FC: FieldChip<F>>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
+    P: impl Into<EcPoint<F, FC::FieldPoint>>,
 ) -> EcPoint<F, FC::FieldPoint> {
+    let P = P.into();
     // removed optimization that computes `2 * lambda` while assigning witness to `lambda` simultaneously, in favor of readability. The difference is just copying `lambda` once
     let two_y = chip.scalar_mul_no_carry(ctx, &P.y, 2);
     let three_x = chip.scalar_mul_no_carry(ctx, &P.x, 3);
-    let three_x_sq = chip.mul_no_carry(ctx, &three_x, &P.x);
-    let lambda = chip.divide_unsafe(ctx, &three_x_sq, &two_y);
+    let three_x_sq = chip.mul_no_carry(ctx, three_x, &P.x);
+    let lambda = chip.divide_unsafe(ctx, three_x_sq, two_y);
 
     // x_3 = lambda^2 - 2 x % p
     let lambda_sq = chip.mul_no_carry(ctx, &lambda, &lambda);
     let two_x = chip.scalar_mul_no_carry(ctx, &P.x, 2);
-    let x_3_no_carry = chip.sub_no_carry(ctx, &lambda_sq, &two_x);
-    let x_3 = chip.carry_mod(ctx, &x_3_no_carry);
+    let x_3_no_carry = chip.sub_no_carry(ctx, lambda_sq, two_x);
+    let x_3 = chip.carry_mod(ctx, x_3_no_carry);
 
     // y_3 = lambda (x - x_3) - y % p
-    let dx = chip.sub_no_carry(ctx, &P.x, &x_3);
-    let lambda_dx = chip.mul_no_carry(ctx, &lambda, &dx);
-    let y_3_no_carry = chip.sub_no_carry(ctx, &lambda_dx, &P.y);
-    let y_3 = chip.carry_mod(ctx, &y_3_no_carry);
+    let dx = chip.sub_no_carry(ctx, P.x, &x_3);
+    let lambda_dx = chip.mul_no_carry(ctx, lambda, dx);
+    let y_3_no_carry = chip.sub_no_carry(ctx, lambda_dx, P.y);
+    let y_3 = chip.carry_mod(ctx, y_3_no_carry);
 
-    EcPoint::construct(x_3, y_3)
+    EcPoint::new(x_3, y_3)
 }
 
 /// Implements:
@@ -188,101 +293,137 @@ pub fn ec_double<F: PrimeField, FC: FieldChip<F>>(
 pub fn ec_double_and_add_unequal<F: PrimeField, FC: FieldChip<F>>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
-    Q: &EcPoint<F, FC::FieldPoint>,
+    P: impl Into<ComparableEcPoint<F, FC>>,
+    Q: impl Into<ComparableEcPoint<F, FC>>,
     is_strict: bool,
 ) -> EcPoint<F, FC::FieldPoint> {
+    let P = P.into();
+    let Q = Q.into();
+    let mut x_0 = None;
     if is_strict {
         // constrains that P.x != Q.x
-        let x_is_equal = chip.is_equal_unenforced(ctx, &P.x, &Q.x);
-        chip.range().gate().assert_is_const(ctx, &x_is_equal, &F::zero());
+        let [x0, x1] = [&P, &Q].map(|pt| match pt {
+            ComparableEcPoint::Strict(pt) => pt.x.clone(),
+            ComparableEcPoint::NonStrict(pt) => chip.enforce_less_than(ctx, pt.x.clone()),
+        });
+        let x_is_equal = chip.is_equal_unenforced(ctx, x0.clone(), x1);
+        chip.gate().assert_is_const(ctx, &x_is_equal, &F::zero());
+        x_0 = Some(x0);
     }
+    let P = EcPoint::from(P);
+    let Q = EcPoint::from(Q);
 
     let dx = chip.sub_no_carry(ctx, &Q.x, &P.x);
-    let dy = chip.sub_no_carry(ctx, &Q.y, &P.y);
-    let lambda_0 = chip.divide_unsafe(ctx, &dy, &dx);
+    let dy = chip.sub_no_carry(ctx, Q.y, &P.y);
+    let lambda_0 = chip.divide_unsafe(ctx, dy, dx);
 
     //  x_2 = lambda_0^2 - x_0 - x_1 (mod p)
     let lambda_0_sq = chip.mul_no_carry(ctx, &lambda_0, &lambda_0);
-    let lambda_0_sq_minus_x_0 = chip.sub_no_carry(ctx, &lambda_0_sq, &P.x);
-    let x_2_no_carry = chip.sub_no_carry(ctx, &lambda_0_sq_minus_x_0, &Q.x);
-    let x_2 = chip.carry_mod(ctx, &x_2_no_carry);
+    let lambda_0_sq_minus_x_0 = chip.sub_no_carry(ctx, lambda_0_sq, &P.x);
+    let x_2_no_carry = chip.sub_no_carry(ctx, lambda_0_sq_minus_x_0, Q.x);
+    let x_2 = chip.carry_mod(ctx, x_2_no_carry);
 
     if is_strict {
+        let x_2 = chip.enforce_less_than(ctx, x_2.clone());
         // TODO: when can we remove this check?
         // constrains that x_2 != x_0
-        let x_is_equal = chip.is_equal_unenforced(ctx, &P.x, &x_2);
+        let x_is_equal = chip.is_equal_unenforced(ctx, x_0.unwrap(), x_2);
         chip.range().gate().assert_is_const(ctx, &x_is_equal, &F::zero());
     }
     // lambda_1 = lambda_0 + 2 * y_0 / (x_2 - x_0)
     let two_y_0 = chip.scalar_mul_no_carry(ctx, &P.y, 2);
     let x_2_minus_x_0 = chip.sub_no_carry(ctx, &x_2, &P.x);
-    let lambda_1_minus_lambda_0 = chip.divide_unsafe(ctx, &two_y_0, &x_2_minus_x_0);
-    let lambda_1_no_carry = chip.add_no_carry(ctx, &lambda_0, &lambda_1_minus_lambda_0);
+    let lambda_1_minus_lambda_0 = chip.divide_unsafe(ctx, two_y_0, x_2_minus_x_0);
+    let lambda_1_no_carry = chip.add_no_carry(ctx, lambda_0, lambda_1_minus_lambda_0);
 
     // x_res = lambda_1^2 - x_0 - x_2
     let lambda_1_sq_nc = chip.mul_no_carry(ctx, &lambda_1_no_carry, &lambda_1_no_carry);
-    let lambda_1_sq_minus_x_0 = chip.sub_no_carry(ctx, &lambda_1_sq_nc, &P.x);
-    let x_res_no_carry = chip.sub_no_carry(ctx, &lambda_1_sq_minus_x_0, &x_2);
-    let x_res = chip.carry_mod(ctx, &x_res_no_carry);
+    let lambda_1_sq_minus_x_0 = chip.sub_no_carry(ctx, lambda_1_sq_nc, &P.x);
+    let x_res_no_carry = chip.sub_no_carry(ctx, lambda_1_sq_minus_x_0, x_2);
+    let x_res = chip.carry_mod(ctx, x_res_no_carry);
 
     // y_res = lambda_1 * (x_res - x_0) - y_0
-    let x_res_minus_x_0 = chip.sub_no_carry(ctx, &x_res, &P.x);
-    let lambda_1_x_res_minus_x_0 = chip.mul_no_carry(ctx, &lambda_1_no_carry, &x_res_minus_x_0);
-    let y_res_no_carry = chip.sub_no_carry(ctx, &lambda_1_x_res_minus_x_0, &P.y);
-    let y_res = chip.carry_mod(ctx, &y_res_no_carry);
+    let x_res_minus_x_0 = chip.sub_no_carry(ctx, &x_res, P.x);
+    let lambda_1_x_res_minus_x_0 = chip.mul_no_carry(ctx, lambda_1_no_carry, x_res_minus_x_0);
+    let y_res_no_carry = chip.sub_no_carry(ctx, lambda_1_x_res_minus_x_0, P.y);
+    let y_res = chip.carry_mod(ctx, y_res_no_carry);
 
-    EcPoint::construct(x_res, y_res)
+    EcPoint::new(x_res, y_res)
 }
 
 pub fn ec_select<F: PrimeField, FC>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
-    Q: &EcPoint<F, FC::FieldPoint>,
+    P: EcPoint<F, FC::FieldPoint>,
+    Q: EcPoint<F, FC::FieldPoint>,
     sel: AssignedValue<F>,
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
 {
-    let Rx = chip.select(ctx, &P.x, &Q.x, sel);
-    let Ry = chip.select(ctx, &P.y, &Q.y, sel);
-    EcPoint::construct(Rx, Ry)
+    let Rx = chip.select(ctx, P.x, Q.x, sel);
+    let Ry = chip.select(ctx, P.y, Q.y, sel);
+    EcPoint::new(Rx, Ry)
 }
 
 // takes the dot product of points with sel, where each is intepreted as
 // a _vector_
-pub fn ec_select_by_indicator<F: PrimeField, FC>(
+pub fn ec_select_by_indicator<F: PrimeField, FC, Pt>(
     chip: &FC,
     ctx: &mut Context<F>,
-    points: &[EcPoint<F, FC::FieldPoint>],
+    points: &[Pt],
     coeffs: &[AssignedValue<F>],
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
+    Pt: Into<EcPoint<F, FC::FieldPoint>> + Clone,
 {
-    let x_coords = points.iter().map(|P| P.x.clone()).collect::<Vec<_>>();
-    let y_coords = points.iter().map(|P| P.y.clone()).collect::<Vec<_>>();
-    let Rx = chip.select_by_indicator(ctx, &x_coords, coeffs);
-    let Ry = chip.select_by_indicator(ctx, &y_coords, coeffs);
-    EcPoint::construct(Rx, Ry)
+    let (x, y): (Vec<_>, Vec<_>) = points
+        .iter()
+        .map(|P| {
+            let P: EcPoint<_, _> = P.clone().into();
+            (P.x, P.y)
+        })
+        .unzip();
+    let Rx = chip.select_by_indicator(ctx, &x, coeffs);
+    let Ry = chip.select_by_indicator(ctx, &y, coeffs);
+    EcPoint::new(Rx, Ry)
 }
 
 // `sel` is little-endian binary
-pub fn ec_select_from_bits<F: PrimeField, FC>(
+pub fn ec_select_from_bits<F: PrimeField, FC, Pt>(
     chip: &FC,
     ctx: &mut Context<F>,
-    points: &[EcPoint<F, FC::FieldPoint>],
+    points: &[Pt],
     sel: &[AssignedValue<F>],
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
+    Pt: Into<EcPoint<F, FC::FieldPoint>> + Clone,
 {
     let w = sel.len();
-    let num_points = points.len();
-    assert_eq!(1 << w, num_points);
+    assert_eq!(1 << w, points.len());
     let coeffs = chip.range().gate().bits_to_indicator(ctx, sel);
     ec_select_by_indicator(chip, ctx, points, &coeffs)
+}
+
+// `sel` is little-endian binary
+pub fn strict_ec_select_from_bits<F: PrimeField, FC>(
+    chip: &FC,
+    ctx: &mut Context<F>,
+    points: &[StrictEcPoint<F, FC>],
+    sel: &[AssignedValue<F>],
+) -> StrictEcPoint<F, FC>
+where
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint> + Selectable<F, FC::ReducedFieldPoint>,
+{
+    let w = sel.len();
+    assert_eq!(1 << w, points.len());
+    let coeffs = chip.range().gate().bits_to_indicator(ctx, sel);
+    let (x, y): (Vec<_>, Vec<_>) = points.iter().map(|pt| (pt.x.clone(), pt.y.clone())).unzip();
+    let x = chip.select_by_indicator(ctx, &x, &coeffs);
+    let y = chip.select_by_indicator(ctx, &y, &coeffs);
+    StrictEcPoint::new(x, y)
 }
 
 // computes [scalar] * P on y^2 = x^3 + b
@@ -296,13 +437,13 @@ where
 pub fn scalar_multiply<F: PrimeField, FC>(
     chip: &FC,
     ctx: &mut Context<F>,
-    P: &EcPoint<F, FC::FieldPoint>,
+    P: EcPoint<F, FC::FieldPoint>,
     scalar: Vec<AssignedValue<F>>,
     max_bits: usize,
     window_bits: usize,
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
 {
     assert!(!scalar.is_empty());
     assert!((max_bits as u64) <= modulus::<F>().bits());
@@ -347,16 +488,16 @@ where
     cached_points.push(P.clone());
     for idx in 2..cache_size {
         if idx == 2 {
-            let double = ec_double(chip, ctx, P /*, b*/);
+            let double = ec_double(chip, ctx, &P);
             cached_points.push(double);
         } else {
-            let new_point = ec_add_unequal(chip, ctx, &cached_points[idx - 1], P, false);
+            let new_point = ec_add_unequal(chip, ctx, &cached_points[idx - 1], &P, false);
             cached_points.push(new_point);
         }
     }
 
     // if all the starting window bits are 0, get start_point = P
-    let mut curr_point = ec_select_from_bits::<F, FC>(
+    let mut curr_point = ec_select_from_bits(
         chip,
         ctx,
         &cached_points,
@@ -366,9 +507,9 @@ where
     for idx in 1..num_windows {
         let mut mult_point = curr_point.clone();
         for _ in 0..window_bits {
-            mult_point = ec_double(chip, ctx, &mult_point);
+            mult_point = ec_double(chip, ctx, mult_point);
         }
-        let add_point = ec_select_from_bits::<F, FC>(
+        let add_point = ec_select_from_bits(
             chip,
             ctx,
             &cached_points,
@@ -376,29 +517,28 @@ where
                 [rounded_bitlen - window_bits * (idx + 1)..rounded_bitlen - window_bits * idx],
         );
         let mult_and_add = ec_add_unequal(chip, ctx, &mult_point, &add_point, false);
-        let is_started_point =
-            ec_select(chip, ctx, &mult_point, &mult_and_add, is_zero_window[idx]);
+        let is_started_point = ec_select(chip, ctx, mult_point, mult_and_add, is_zero_window[idx]);
 
         curr_point =
-            ec_select(chip, ctx, &is_started_point, &add_point, is_started[window_bits * idx]);
+            ec_select(chip, ctx, is_started_point, add_point, is_started[window_bits * idx]);
     }
     curr_point
 }
 
-pub fn is_on_curve<F, FC, C>(chip: &FC, ctx: &mut Context<F>, P: &EcPoint<F, FC::FieldPoint>)
+/// Checks that `P` is indeed a point on the elliptic curve `C`.
+pub fn check_is_on_curve<F, FC, C>(chip: &FC, ctx: &mut Context<F>, P: &EcPoint<F, FC::FieldPoint>)
 where
     F: PrimeField,
     FC: FieldChip<F>,
     C: CurveAffine<Base = FC::FieldType>,
 {
     let lhs = chip.mul_no_carry(ctx, &P.y, &P.y);
-    let mut rhs = chip.mul(ctx, &P.x, &P.x);
-    rhs = chip.mul_no_carry(ctx, &rhs, &P.x);
+    let mut rhs = chip.mul(ctx, &P.x, &P.x).into();
+    rhs = chip.mul_no_carry(ctx, rhs, &P.x);
 
-    let b = FC::fe_to_constant(C::b());
-    rhs = chip.add_constant_no_carry(ctx, &rhs, b);
-    let diff = chip.sub_no_carry(ctx, &lhs, &rhs);
-    chip.check_carry_mod_to_zero(ctx, &diff)
+    rhs = chip.add_constant_no_carry(ctx, rhs, C::b());
+    let diff = chip.sub_no_carry(ctx, lhs, rhs);
+    chip.check_carry_mod_to_zero(ctx, diff)
 }
 
 pub fn load_random_point<F, FC, C>(chip: &FC, ctx: &mut Context<F>) -> EcPoint<F, FC::FieldPoint>
@@ -409,16 +549,27 @@ where
 {
     let base_point: C = C::CurveExt::random(ChaCha20Rng::from_entropy()).to_affine();
     let (x, y) = base_point.into_coordinates();
-    let pt_x = FC::fe_to_witness(&x);
-    let pt_y = FC::fe_to_witness(&y);
     let base = {
-        let x_overflow = chip.load_private(ctx, pt_x);
-        let y_overflow = chip.load_private(ctx, pt_y);
-        EcPoint::construct(x_overflow, y_overflow)
+        let x_overflow = chip.load_private(ctx, x);
+        let y_overflow = chip.load_private(ctx, y);
+        EcPoint::new(x_overflow, y_overflow)
     };
     // for above reason we still need to constrain that the witness is on the curve
-    is_on_curve::<F, FC, C>(chip, ctx, &base);
+    check_is_on_curve::<F, FC, C>(chip, ctx, &base);
     base
+}
+
+pub fn into_strict_point<F, FC>(
+    chip: &FC,
+    ctx: &mut Context<F>,
+    pt: EcPoint<F, FC::FieldPoint>,
+) -> StrictEcPoint<F, FC>
+where
+    F: PrimeField,
+    FC: FieldChip<F>,
+{
+    let x = chip.enforce_less_than(ctx, pt.x);
+    StrictEcPoint::new(x, pt.y)
 }
 
 // need to supply an extra generic `C` implementing `CurveAffine` trait in order to generate random witness points on the curve in question
@@ -436,7 +587,7 @@ pub fn multi_scalar_multiply<F: PrimeField, FC, C>(
     window_bits: usize,
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
     C: CurveAffineExt<Base = FC::FieldType>,
 {
     let k = P.len();
@@ -463,7 +614,7 @@ where
         })
         .collect_vec();
 
-    // load random C point as witness
+    // load any sufficiently generic C point as witness
     // note that while we load a random point, an adversary would load a specifically chosen point, so we must carefully handle edge cases with constraints
     let base = load_random_point::<F, FC, C>(chip, ctx);
     // contains random base points [A, ..., 2^{w + k - 1} * A]
@@ -490,17 +641,17 @@ where
             &rand_start_vec[idx + window_bits],
             false,
         );
-        chip.enforce_less_than(ctx, point.x());
-        chip.enforce_less_than(ctx, neg_mult_rand_start.x());
+        let point = into_strict_point(chip, ctx, point.clone());
+        let neg_mult_rand_start = into_strict_point(chip, ctx, neg_mult_rand_start);
         // cached_points[i][0..cache_size] stores (1 - 2^w) * 2^i * A + [0..cache_size] * P_i
         cached_points.push(neg_mult_rand_start);
         for _ in 0..(cache_size - 1) {
-            let prev = cached_points.last().unwrap();
+            let prev = cached_points.last().unwrap().clone();
             // adversary could pick `A` so add equal case occurs, so we must use strict add_unequal
-            let mut new_point = ec_add_unequal(chip, ctx, prev, point, true);
+            let mut new_point = ec_add_unequal(chip, ctx, &prev, &point, true);
             // special case for when P[idx] = O
-            new_point = ec_select(chip, ctx, prev, &new_point, is_infinity);
-            chip.enforce_less_than(ctx, new_point.x());
+            new_point = ec_select(chip, ctx, prev.into(), new_point, is_infinity);
+            let new_point = into_strict_point(chip, ctx, new_point);
             cached_points.push(new_point);
         }
     }
@@ -509,38 +660,35 @@ where
     // note k can be large (e.g., 800) so 2^{k+1} may be larger than the order of A
     // random fact: 2^{k + 1} - 1 can be prime: see Mersenne primes
     // TODO: I don't see a way to rule out 2^{k+1} A = +-A case in general, so will use strict sub_unequal
-    let start_point = if k < F::CAPACITY as usize {
-        ec_sub_unequal(chip, ctx, &rand_start_vec[k], &rand_start_vec[0], false)
-    } else {
-        chip.enforce_less_than(ctx, rand_start_vec[k].x());
-        chip.enforce_less_than(ctx, rand_start_vec[0].x());
-        ec_sub_unequal(chip, ctx, &rand_start_vec[k], &rand_start_vec[0], true)
-    };
+    let start_point = ec_sub_unequal(
+        chip,
+        ctx,
+        &rand_start_vec[k],
+        &rand_start_vec[0],
+        k >= F::CAPACITY as usize,
+    );
     let mut curr_point = start_point.clone();
 
     // compute \sum_i x_i P_i + (2^{k + 1} - 1) * A
     for idx in 0..num_windows {
         for _ in 0..window_bits {
-            curr_point = ec_double(chip, ctx, &curr_point);
+            curr_point = ec_double(chip, ctx, curr_point);
         }
         for (cached_points, rounded_bits) in
             cached_points.chunks(cache_size).zip(rounded_bits.chunks(rounded_bitlen))
         {
-            let add_point = ec_select_from_bits::<F, FC>(
+            let add_point = ec_select_from_bits(
                 chip,
                 ctx,
                 cached_points,
                 &rounded_bits
                     [rounded_bitlen - window_bits * (idx + 1)..rounded_bitlen - window_bits * idx],
             );
-            chip.enforce_less_than(ctx, curr_point.x());
             // this all needs strict add_unequal since A can be non-randomly chosen by adversary
-            curr_point = ec_add_unequal(chip, ctx, &curr_point, &add_point, true);
+            curr_point = ec_add_unequal(chip, ctx, curr_point, add_point, true);
         }
     }
-    chip.enforce_less_than(ctx, start_point.x());
-    chip.enforce_less_than(ctx, curr_point.x());
-    ec_sub_unequal(chip, ctx, &curr_point, &start_point, true)
+    ec_sub_unequal(chip, ctx, curr_point, start_point, true)
 }
 
 pub fn get_naf(mut exp: Vec<u64>) -> Vec<i8> {
@@ -608,26 +756,29 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
         self.field_chip
     }
 
-    pub fn load_private(
+    /// Does not constrain witness to lie on curve
+    pub fn load_private_unchecked(
         &self,
         ctx: &mut Context<F>,
-        point: (FC::FieldType, FC::FieldType),
+        (x, y): (FC::FieldType, FC::FieldType),
     ) -> EcPoint<F, FC::FieldPoint> {
-        let (x, y) = (FC::fe_to_witness(&point.0), FC::fe_to_witness(&point.1));
-
         let x_assigned = self.field_chip.load_private(ctx, x);
         let y_assigned = self.field_chip.load_private(ctx, y);
 
-        EcPoint::construct(x_assigned, y_assigned)
+        EcPoint::new(x_assigned, y_assigned)
     }
 
     /// Does not constrain witness to lie on curve
-    pub fn assign_point<C>(&self, ctx: &mut Context<F>, g: C) -> EcPoint<F, FC::FieldPoint>
+    pub fn assign_point_unchecked<C>(
+        &self,
+        ctx: &mut Context<F>,
+        g: C,
+    ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt<Base = FC::FieldType>,
     {
         let (x, y) = g.into_coordinates();
-        self.load_private(ctx, (x, y))
+        self.load_private_unchecked(ctx, (x, y))
     }
 
     pub fn assign_constant_point<C>(&self, ctx: &mut Context<F>, g: C) -> EcPoint<F, FC::FieldPoint>
@@ -635,11 +786,10 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
         C: CurveAffineExt<Base = FC::FieldType>,
     {
         let (x, y) = g.into_coordinates();
-        let [x, y] = [x, y].map(FC::fe_to_constant);
         let x = self.field_chip.load_constant(ctx, x);
         let y = self.field_chip.load_constant(ctx, y);
 
-        EcPoint::construct(x, y)
+        EcPoint::new(x, y)
     }
 
     pub fn load_random_point<C>(&self, ctx: &mut Context<F>) -> EcPoint<F, FC::FieldPoint>
@@ -653,7 +803,7 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     where
         C: CurveAffine<Base = FC::FieldType>,
     {
-        is_on_curve::<F, FC, C>(self.field_chip, ctx, P)
+        check_is_on_curve::<F, FC, C>(self.field_chip, ctx, P)
     }
 
     pub fn is_on_curve_or_infinity<C>(
@@ -666,15 +816,14 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
         C::Base: ff::PrimeField,
     {
         let lhs = self.field_chip.mul_no_carry(ctx, &P.y, &P.y);
-        let mut rhs = self.field_chip.mul(ctx, &P.x, &P.x);
-        rhs = self.field_chip.mul_no_carry(ctx, &rhs, &P.x);
+        let mut rhs = self.field_chip.mul(ctx, &P.x, &P.x).into();
+        rhs = self.field_chip.mul_no_carry(ctx, rhs, &P.x);
 
-        let b = FC::fe_to_constant(C::b());
-        rhs = self.field_chip.add_constant_no_carry(ctx, &rhs, b);
-        let mut diff = self.field_chip.sub_no_carry(ctx, &lhs, &rhs);
-        diff = self.field_chip.carry_mod(ctx, &diff);
+        rhs = self.field_chip.add_constant_no_carry(ctx, rhs, C::b());
+        let diff = self.field_chip.sub_no_carry(ctx, lhs, rhs);
+        let diff = self.field_chip.carry_mod(ctx, diff);
 
-        let is_on_curve = self.field_chip.is_zero(ctx, &diff);
+        let is_on_curve = self.field_chip.is_zero(ctx, diff);
 
         let x_is_zero = self.field_chip.is_zero(ctx, &P.x);
         let y_is_zero = self.field_chip.is_zero(ctx, &P.y);
@@ -685,9 +834,10 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     pub fn negate(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
+        P: impl Into<EcPoint<F, FC::FieldPoint>>,
     ) -> EcPoint<F, FC::FieldPoint> {
-        EcPoint::construct(P.x.clone(), self.field_chip.negate(ctx, &P.y))
+        let P = P.into();
+        EcPoint::new(P.x, self.field_chip.negate(ctx, P.y))
     }
 
     /// Assumes that P.x != Q.x
@@ -695,8 +845,8 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     pub fn add_unequal(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
-        Q: &EcPoint<F, FC::FieldPoint>,
+        P: impl Into<ComparableEcPoint<F, FC>>,
+        Q: impl Into<ComparableEcPoint<F, FC>>,
         is_strict: bool,
     ) -> EcPoint<F, FC::FieldPoint> {
         ec_add_unequal(self.field_chip, ctx, P, Q, is_strict)
@@ -707,8 +857,8 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     pub fn sub_unequal(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
-        Q: &EcPoint<F, FC::FieldPoint>,
+        P: impl Into<ComparableEcPoint<F, FC>>,
+        Q: impl Into<ComparableEcPoint<F, FC>>,
         is_strict: bool,
     ) -> EcPoint<F, FC::FieldPoint> {
         ec_sub_unequal(self.field_chip, ctx, P, Q, is_strict)
@@ -717,7 +867,7 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     pub fn double(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
+        P: impl Into<EcPoint<F, FC::FieldPoint>>,
     ) -> EcPoint<F, FC::FieldPoint> {
         ec_double(self.field_chip, ctx, P)
     }
@@ -725,55 +875,54 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     pub fn is_equal(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
-        Q: &EcPoint<F, FC::FieldPoint>,
+        P: EcPoint<F, FC::FieldPoint>,
+        Q: EcPoint<F, FC::FieldPoint>,
     ) -> AssignedValue<F> {
         // TODO: optimize
-        let x_is_equal = self.field_chip.is_equal(ctx, &P.x, &Q.x);
-        let y_is_equal = self.field_chip.is_equal(ctx, &P.y, &Q.y);
+        let x_is_equal = self.field_chip.is_equal(ctx, P.x, Q.x);
+        let y_is_equal = self.field_chip.is_equal(ctx, P.y, Q.y);
         self.field_chip.range().gate().and(ctx, x_is_equal, y_is_equal)
     }
 
     pub fn assert_equal(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
-        Q: &EcPoint<F, FC::FieldPoint>,
+        P: EcPoint<F, FC::FieldPoint>,
+        Q: EcPoint<F, FC::FieldPoint>,
     ) {
-        self.field_chip.assert_equal(ctx, &P.x, &Q.x);
-        self.field_chip.assert_equal(ctx, &P.y, &Q.y);
+        self.field_chip.assert_equal(ctx, P.x, Q.x);
+        self.field_chip.assert_equal(ctx, P.y, Q.y);
     }
 
     pub fn sum<'b, 'v: 'b, C>(
         &self,
         ctx: &mut Context<F>,
-        points: impl Iterator<Item = &'b EcPoint<F, FC::FieldPoint>>,
+        points: impl IntoIterator<Item = EcPoint<F, FC::FieldPoint>>,
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt<Base = FC::FieldType>,
         FC::FieldPoint: 'b,
     {
         let rand_point = self.load_random_point::<C>(ctx);
-        self.field_chip.enforce_less_than(ctx, rand_point.x());
+        let rand_point = into_strict_point(self.field_chip, ctx, rand_point);
         let mut acc = rand_point.clone();
         for point in points {
-            self.field_chip.enforce_less_than(ctx, point.x());
-            acc = self.add_unequal(ctx, &acc, point, true);
-            self.field_chip.enforce_less_than(ctx, acc.x());
+            let _acc = self.add_unequal(ctx, acc, point, true);
+            acc = into_strict_point(self.field_chip, ctx, _acc);
         }
-        self.sub_unequal(ctx, &acc, &rand_point, true)
+        self.sub_unequal(ctx, acc, rand_point, true)
     }
 }
 
 impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC>
 where
-    FC: Selectable<F, Point = FC::FieldPoint>,
+    FC: Selectable<F, FC::FieldPoint>,
 {
     pub fn select(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
-        Q: &EcPoint<F, FC::FieldPoint>,
+        P: EcPoint<F, FC::FieldPoint>,
+        Q: EcPoint<F, FC::FieldPoint>,
         condition: AssignedValue<F>,
     ) -> EcPoint<F, FC::FieldPoint> {
         ec_select(self.field_chip, ctx, P, Q, condition)
@@ -782,7 +931,7 @@ where
     pub fn scalar_mult(
         &self,
         ctx: &mut Context<F>,
-        P: &EcPoint<F, FC::FieldPoint>,
+        P: EcPoint<F, FC::FieldPoint>,
         scalar: Vec<AssignedValue<F>>,
         max_bits: usize,
         window_bits: usize,
@@ -801,6 +950,7 @@ where
     where
         C: CurveAffineExt<Base = FC::FieldType>,
         C::Base: ff::PrimeField,
+        FC: Selectable<F, FC::ReducedFieldPoint>,
     {
         // window_bits = 4 is optimal from empirical observations
         self.variable_base_msm_in::<C>(thread_pool, P, scalars, max_bits, 4, 0)
@@ -819,6 +969,7 @@ where
     where
         C: CurveAffineExt<Base = FC::FieldType>,
         C::Base: ff::PrimeField,
+        FC: Selectable<F, FC::ReducedFieldPoint>,
     {
         #[cfg(feature = "display")]
         println!("computing length {} MSM", P.len());
@@ -854,10 +1005,7 @@ where
     }
 }
 
-impl<'chip, F: PrimeField, FC: PrimeFieldChip<F>> EccChip<'chip, F, FC>
-where
-    FC::FieldType: PrimeField,
-{
+impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
     // TODO: put a check in place that scalar is < modulus of C::Scalar
     pub fn fixed_base_scalar_mult<C>(
         &self,
@@ -869,8 +1017,7 @@ where
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt,
-        FC: PrimeFieldChip<F, FieldType = C::Base, FieldPoint = CRTInteger<F>>
-            + Selectable<F, Point = FC::FieldPoint>,
+        FC: FieldChip<F, FieldType = C::Base> + Selectable<F, FC::FieldPoint>,
     {
         fixed_base::scalar_multiply::<F, _, _>(
             self.field_chip,
@@ -892,8 +1039,7 @@ where
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt,
-        FC: PrimeFieldChip<F, FieldType = C::Base, FieldPoint = CRTInteger<F>>
-            + Selectable<F, Point = FC::FieldPoint>,
+        FC: FieldChip<F, FieldType = C::Base> + Selectable<F, FC::FieldPoint>,
     {
         self.fixed_base_msm_in::<C>(builder, points, scalars, max_scalar_bits_per_cell, 4, 0)
     }
@@ -914,10 +1060,9 @@ where
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt,
-        FC: PrimeFieldChip<F, FieldType = C::Base, FieldPoint = CRTInteger<F>>
-            + Selectable<F, Point = FC::FieldPoint>,
+        FC: FieldChip<F, FieldType = C::Base> + Selectable<F, FC::FieldPoint>,
     {
-        debug_assert_eq!(points.len(), scalars.len());
+        assert_eq!(points.len(), scalars.len());
         #[cfg(feature = "display")]
         println!("computing length {} fixed base msm", points.len());
 

--- a/halo2-ecc/src/ecc/pippenger.rs
+++ b/halo2-ecc/src/ecc/pippenger.rs
@@ -1,6 +1,6 @@
 use super::{
-    ec_add_unequal, ec_double, ec_select, ec_select_from_bits, ec_sub_unequal, load_random_point,
-    EcPoint,
+    ec_add_unequal, ec_double, ec_select, ec_sub_unequal, into_strict_point, load_random_point,
+    strict_ec_select_from_bits, EcPoint, StrictEcPoint,
 };
 use crate::fields::{FieldChip, PrimeField, Selectable};
 use halo2_base::{
@@ -73,9 +73,9 @@ pub fn multi_product<F: PrimeField, FC, C>(
     points: &[EcPoint<F, FC::FieldPoint>],
     bool_scalars: &[Vec<AssignedValue<F>>],
     clumping_factor: usize,
-) -> (Vec<EcPoint<F, FC::FieldPoint>>, EcPoint<F, FC::FieldPoint>)
+) -> (Vec<StrictEcPoint<F, FC>>, EcPoint<F, FC::FieldPoint>)
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint> + Selectable<F, FC::ReducedFieldPoint>,
     C: CurveAffineExt<Base = FC::FieldType>,
 {
     let c = clumping_factor; // this is `b` in Section 3 of Bootle
@@ -84,63 +84,64 @@ where
     // we use a trick from halo2wrong where we load a random C point as witness
     // note that while we load a random point, an adversary could load a specifically chosen point, so we must carefully handle edge cases with constraints
     // TODO: an alternate approach is to use Fiat-Shamir transform (with Poseidon) to hash all the inputs (points, bool_scalars, ...) to get the random point. This could be worth it for large MSMs as we get savings from `add_unequal` in "non-strict" mode. Perhaps not worth the trouble / security concern, though.
-    let rand_base = load_random_point::<F, FC, C>(chip, ctx);
+    let any_base = load_random_point::<F, FC, C>(chip, ctx);
 
     let mut acc = Vec::with_capacity(bool_scalars.len());
 
     let mut bucket = Vec::with_capacity(1 << c);
-    let mut rand_point = rand_base.clone();
+    let mut any_point = any_base.clone();
     for (round, points_clump) in points.chunks(c).enumerate() {
         // compute all possible multi-products of elements in points[round * c .. round * (c+1)]
 
         // for later addition collision-prevension, we need a different random point per round
         // we take 2^round * rand_base
         if round > 0 {
-            rand_point = ec_double(chip, ctx, &rand_point);
+            any_point = ec_double(chip, ctx, any_point);
         }
         // stores { rand_point, rand_point + points[0], rand_point + points[1], rand_point + points[0] + points[1] , ... }
         // since rand_point is random, we can always use add_unequal (with strict constraint checking that the points are indeed unequal and not negative of each other)
         bucket.clear();
-        chip.enforce_less_than(ctx, rand_point.x());
-        bucket.push(rand_point.clone());
+        let strict_any_point = into_strict_point(chip, ctx, any_point.clone());
+        bucket.push(strict_any_point);
         for (i, point) in points_clump.iter().enumerate() {
             // we allow for points[i] to be the point at infinity, represented by (0, 0) in affine coordinates
             // this can be checked by points[i].y == 0 iff points[i] == O
             let is_infinity = chip.is_zero(ctx, &point.y);
-            chip.enforce_less_than(ctx, point.x());
+            let point = into_strict_point(chip, ctx, point.clone());
 
             for j in 0..(1 << i) {
-                let mut new_point = ec_add_unequal(chip, ctx, &bucket[j], point, true);
+                let mut new_point = ec_add_unequal(chip, ctx, &bucket[j], &point, true);
                 // if points[i] is point at infinity, do nothing
-                new_point = ec_select(chip, ctx, &bucket[j], &new_point, is_infinity);
-                chip.enforce_less_than(ctx, new_point.x());
+                new_point = ec_select(chip, ctx, (&bucket[j]).into(), new_point, is_infinity);
+                let new_point = into_strict_point(chip, ctx, new_point);
                 bucket.push(new_point);
             }
         }
 
         // for each j, select using clump in e[j][i=...]
         for (j, bits) in bool_scalars.iter().enumerate() {
-            let multi_prod = ec_select_from_bits::<F, _>(
+            let multi_prod = strict_ec_select_from_bits(
                 chip,
                 ctx,
                 &bucket,
                 &bits[round * c..round * c + points_clump.len()],
             );
+            // since `bucket` is all `StrictEcPoint` and we are selecting from it, we know `multi_prod` is StrictEcPoint
             // everything in bucket has already been enforced
             if round == 0 {
                 acc.push(multi_prod);
             } else {
-                acc[j] = ec_add_unequal(chip, ctx, &acc[j], &multi_prod, true);
-                chip.enforce_less_than(ctx, acc[j].x());
+                let _acc = ec_add_unequal(chip, ctx, &acc[j], multi_prod, true);
+                acc[j] = into_strict_point(chip, ctx, _acc);
             }
         }
     }
 
     // we have acc[j] = G'[j] + (2^num_rounds - 1) * rand_base
-    rand_point = ec_double(chip, ctx, &rand_point);
-    rand_point = ec_sub_unequal(chip, ctx, &rand_point, &rand_base, false);
+    any_point = ec_double(chip, ctx, any_point);
+    any_point = ec_sub_unequal(chip, ctx, any_point, any_base, false);
 
-    (acc, rand_point)
+    (acc, any_point)
 }
 
 /// Currently does not support if the final answer is actually the point at infinity (meaning constraints will fail in that case)
@@ -158,7 +159,7 @@ pub fn multi_exp<F: PrimeField, FC, C>(
     clump_factor: usize,
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint> + Selectable<F, FC::ReducedFieldPoint>,
     C: CurveAffineExt<Base = FC::FieldType>,
 {
     // let (points, bool_scalars) = decompose::<F, _>(chip, ctx, points, scalars, max_scalar_bits_per_cell, radix);
@@ -178,29 +179,26 @@ where
         }
     }
 
-    let (mut agg, rand_point) =
+    let (mut agg, any_point) =
         multi_product::<F, FC, C>(chip, ctx, points, &bool_scalars, clump_factor);
     // everything in agg has been enforced
 
     // compute sum_{k=0..t} agg[k] * 2^{radix * k} - (sum_k 2^{radix * k}) * rand_point
     // (sum_{k=0..t} 2^{radix * k}) = (2^{radix * t} - 1)/(2^radix - 1)
-    let mut sum = agg.pop().unwrap();
-    let mut rand_sum = rand_point.clone();
+    let mut sum = agg.pop().unwrap().into();
+    let mut any_sum = any_point.clone();
     for g in agg.iter().rev() {
-        rand_sum = ec_double(chip, ctx, &rand_sum);
+        any_sum = ec_double(chip, ctx, any_sum);
         // cannot use ec_double_and_add_unequal because you cannot guarantee that `sum != g`
-        sum = ec_double(chip, ctx, &sum);
-        chip.enforce_less_than(ctx, sum.x());
-        sum = ec_add_unequal(chip, ctx, &sum, g, true);
+        sum = ec_double(chip, ctx, sum);
+        sum = ec_add_unequal(chip, ctx, sum, g, true);
     }
 
-    rand_sum = ec_double(chip, ctx, &rand_sum);
+    any_sum = ec_double(chip, ctx, any_sum);
     // assume 2^scalar_bits != +-1 mod modulus::<F>()
-    rand_sum = ec_sub_unequal(chip, ctx, &rand_sum, &rand_point, false);
+    any_sum = ec_sub_unequal(chip, ctx, any_sum, any_point, false);
 
-    chip.enforce_less_than(ctx, sum.x());
-    chip.enforce_less_than(ctx, rand_sum.x());
-    ec_sub_unequal(chip, ctx, &sum, &rand_sum, true)
+    ec_sub_unequal(chip, ctx, sum, any_sum, true)
 }
 
 /// Multi-thread witness generation for multi-scalar multiplication.
@@ -223,7 +221,7 @@ pub fn multi_exp_par<F: PrimeField, FC, C>(
     phase: usize,
 ) -> EcPoint<F, FC::FieldPoint>
 where
-    FC: FieldChip<F> + Selectable<F, Point = FC::FieldPoint>,
+    FC: FieldChip<F> + Selectable<F, FC::FieldPoint> + Selectable<F, FC::ReducedFieldPoint>,
     C: CurveAffineExt<Base = FC::FieldType>,
 {
     // let (points, bool_scalars) = decompose::<F, _>(chip, ctx, points, scalars, max_scalar_bits_per_cell, radix);
@@ -251,11 +249,11 @@ where
 
     let c = clump_factor;
     let num_rounds = (points.len() + c - 1) / c;
-    let rand_base = load_random_point::<F, FC, C>(chip, ctx);
-    let mut rand_points = Vec::with_capacity(num_rounds);
-    rand_points.push(rand_base);
+    let any_base = load_random_point::<F, FC, C>(chip, ctx);
+    let mut any_points = Vec::with_capacity(num_rounds);
+    any_points.push(any_base);
     for _ in 1..num_rounds {
-        rand_points.push(ec_double(chip, ctx, rand_points.last().unwrap()));
+        any_points.push(ec_double(chip, ctx, any_points.last().unwrap()));
     }
     // we will use a different thread per round
     // to prevent concurrency issues with context id, we generate all the ids first
@@ -265,36 +263,36 @@ where
     // multi_prods is 2d vector of size `num_rounds` by `scalar_bits`
     let (new_threads, multi_prods): (Vec<_>, Vec<_>) = points
         .par_chunks(c)
-        .zip(rand_points.par_iter())
+        .zip(any_points.par_iter())
         .zip(thread_ids.into_par_iter())
         .enumerate()
-        .map(|(round, ((points_clump, rand_point), thread_id))| {
+        .map(|(round, ((points_clump, any_point), thread_id))| {
             // compute all possible multi-products of elements in points[round * c .. round * (c+1)]
             // create new thread
             let mut thread = Context::new(witness_gen_only, thread_id);
             let ctx = &mut thread;
-            // stores { rand_point, rand_point + points[0], rand_point + points[1], rand_point + points[0] + points[1] , ... }
+            // stores { any_point, any_point + points[0], any_point + points[1], any_point + points[0] + points[1] , ... }
             let mut bucket = Vec::with_capacity(1 << c);
-            chip.enforce_less_than(ctx, rand_point.x());
-            bucket.push(rand_point.clone());
+            let any_point = into_strict_point(chip, ctx, any_point.clone());
+            bucket.push(any_point);
             for (i, point) in points_clump.iter().enumerate() {
                 // we allow for points[i] to be the point at infinity, represented by (0, 0) in affine coordinates
                 // this can be checked by points[i].y == 0 iff points[i] == O
                 let is_infinity = chip.is_zero(ctx, &point.y);
-                chip.enforce_less_than(ctx, point.x());
+                let point = into_strict_point(chip, ctx, point.clone());
 
                 for j in 0..(1 << i) {
-                    let mut new_point = ec_add_unequal(chip, ctx, &bucket[j], point, true);
+                    let mut new_point = ec_add_unequal(chip, ctx, &bucket[j], &point, true);
                     // if points[i] is point at infinity, do nothing
-                    new_point = ec_select(chip, ctx, &bucket[j], &new_point, is_infinity);
-                    chip.enforce_less_than(ctx, new_point.x());
+                    new_point = ec_select(chip, ctx, (&bucket[j]).into(), new_point, is_infinity);
+                    let new_point = into_strict_point(chip, ctx, new_point);
                     bucket.push(new_point);
                 }
             }
             let multi_prods = bool_scalars
                 .iter()
                 .map(|bits| {
-                    ec_select_from_bits::<F, _>(
+                    strict_ec_select_from_bits(
                         chip,
                         ctx,
                         &bucket,
@@ -317,15 +315,10 @@ where
         .map(|(i, thread_id)| {
             let mut thread = Context::new(witness_gen_only, thread_id);
             let ctx = &mut thread;
-            let mut acc = if multi_prods.len() == 1 {
-                multi_prods[0][i].clone()
-            } else {
-                ec_add_unequal(chip, ctx, &multi_prods[0][i], &multi_prods[1][i], true)
-            };
-            chip.enforce_less_than(ctx, acc.x());
-            for multi_prod in multi_prods.iter().skip(2) {
-                acc = ec_add_unequal(chip, ctx, &acc, &multi_prod[i], true);
-                chip.enforce_less_than(ctx, acc.x());
+            let mut acc = multi_prods[0][i].clone();
+            for multi_prod in multi_prods.iter().skip(1) {
+                let _acc = ec_add_unequal(chip, ctx, &acc, &multi_prod[i], true);
+                acc = into_strict_point(chip, ctx, _acc);
             }
             (thread, acc)
         })
@@ -333,31 +326,27 @@ where
     builder.threads[phase].extend(new_threads);
 
     // gets the LAST thread for single threaded work
-    // warning: don't get any earlier threads, because currently we assume equality constraints in thread i only involves threads <= i
     let ctx = builder.main(phase);
-    // we have agg[j] = G'[j] + (2^num_rounds - 1) * rand_base
-    // let rand_point = (2^num_rounds - 1) * rand_base
+    // we have agg[j] = G'[j] + (2^num_rounds - 1) * any_base
+    // let any_point = (2^num_rounds - 1) * any_base
     // TODO: can we remove all these random point operations somehow?
-    let mut rand_point = ec_double(chip, ctx, rand_points.last().unwrap());
-    rand_point = ec_sub_unequal(chip, ctx, &rand_point, &rand_points[0], false);
+    let mut any_point = ec_double(chip, ctx, any_points.last().unwrap());
+    any_point = ec_sub_unequal(chip, ctx, any_point, &any_points[0], false);
 
     // compute sum_{k=0..scalar_bits} agg[k] * 2^k - (sum_{k=0..scalar_bits} 2^k) * rand_point
     // (sum_{k=0..scalar_bits} 2^k) = (2^scalar_bits - 1)
-    let mut sum = agg.pop().unwrap();
-    let mut rand_sum = rand_point.clone();
+    let mut sum = agg.pop().unwrap().into();
+    let mut any_sum = any_point.clone();
     for g in agg.iter().rev() {
-        rand_sum = ec_double(chip, ctx, &rand_sum);
+        any_sum = ec_double(chip, ctx, any_sum);
         // cannot use ec_double_and_add_unequal because you cannot guarantee that `sum != g`
-        sum = ec_double(chip, ctx, &sum);
-        chip.enforce_less_than(ctx, sum.x());
-        sum = ec_add_unequal(chip, ctx, &sum, g, true);
+        sum = ec_double(chip, ctx, sum);
+        sum = ec_add_unequal(chip, ctx, sum, g, true);
     }
 
-    rand_sum = ec_double(chip, ctx, &rand_sum);
+    any_sum = ec_double(chip, ctx, any_sum);
     // assume 2^scalar_bits != +-1 mod modulus::<F>()
-    rand_sum = ec_sub_unequal(chip, ctx, &rand_sum, &rand_point, false);
+    any_sum = ec_sub_unequal(chip, ctx, any_sum, any_point, false);
 
-    chip.enforce_less_than(ctx, sum.x());
-    chip.enforce_less_than(ctx, rand_sum.x());
-    ec_sub_unequal(chip, ctx, &sum, &rand_sum, true)
+    ec_sub_unequal(chip, ctx, sum, any_sum, true)
 }

--- a/halo2-ecc/src/ecc/tests.rs
+++ b/halo2-ecc/src/ecc/tests.rs
@@ -31,30 +31,30 @@ fn basic_g1_tests<F: PrimeField>(
     let fp_chip = FpChip::<F, Fq>::new(&range, limb_bits, num_limbs);
     let chip = EccChip::new(&fp_chip);
 
-    let P_assigned = chip.load_private(ctx, (P.x, P.y));
-    let Q_assigned = chip.load_private(ctx, (Q.x, Q.y));
+    let P_assigned = chip.load_private_unchecked(ctx, (P.x, P.y));
+    let Q_assigned = chip.load_private_unchecked(ctx, (Q.x, Q.y));
 
     // test add_unequal
-    chip.field_chip.enforce_less_than(ctx, P_assigned.x());
-    chip.field_chip.enforce_less_than(ctx, Q_assigned.x());
+    chip.field_chip.enforce_less_than(ctx, P_assigned.x().clone());
+    chip.field_chip.enforce_less_than(ctx, Q_assigned.x().clone());
     let sum = chip.add_unequal(ctx, &P_assigned, &Q_assigned, false);
-    assert_eq!(sum.x.truncation.to_bigint(limb_bits), sum.x.value);
-    assert_eq!(sum.y.truncation.to_bigint(limb_bits), sum.y.value);
+    assert_eq!(sum.x.0.truncation.to_bigint(limb_bits), sum.x.0.value);
+    assert_eq!(sum.y.0.truncation.to_bigint(limb_bits), sum.y.0.value);
     {
         let actual_sum = G1Affine::from(P + Q);
-        assert_eq!(bigint_to_fe::<Fq>(&sum.x.value), actual_sum.x);
-        assert_eq!(bigint_to_fe::<Fq>(&sum.y.value), actual_sum.y);
+        assert_eq!(bigint_to_fe::<Fq>(&sum.x.0.value), actual_sum.x);
+        assert_eq!(bigint_to_fe::<Fq>(&sum.y.0.value), actual_sum.y);
     }
     println!("add unequal witness OK");
 
     // test double
     let doub = chip.double(ctx, &P_assigned);
-    assert_eq!(doub.x.truncation.to_bigint(limb_bits), doub.x.value);
-    assert_eq!(doub.y.truncation.to_bigint(limb_bits), doub.y.value);
+    assert_eq!(doub.x.0.truncation.to_bigint(limb_bits), doub.x.0.value);
+    assert_eq!(doub.y.0.truncation.to_bigint(limb_bits), doub.y.0.value);
     {
         let actual_doub = G1Affine::from(P * Fr::from(2u64));
-        assert_eq!(bigint_to_fe::<Fq>(&doub.x.value), actual_doub.x);
-        assert_eq!(bigint_to_fe::<Fq>(&doub.y.value), actual_doub.y);
+        assert_eq!(bigint_to_fe::<Fq>(&doub.x.0.value), actual_doub.x);
+        assert_eq!(bigint_to_fe::<Fq>(&doub.y.0.value), actual_doub.y);
     }
     println!("double witness OK");
 }

--- a/halo2-ecc/src/fields/fp12.rs
+++ b/halo2-ecc/src/fields/fp12.rs
@@ -153,19 +153,15 @@ where
         let mut a1b1_coeffs: Vec<FpChip::UnsafeFieldPoint> = Vec::with_capacity(11);
         for i in 0..6 {
             for j in 0..6 {
-                let coeff00 = fp_chip.mul_no_carry(ctx, a[i].clone(), b[j].clone());
-                let coeff01 = fp_chip.mul_no_carry(ctx, a[i].clone(), b[j + 6].clone());
-                let coeff10 = fp_chip.mul_no_carry(ctx, a[i + 6].clone(), b[j].clone());
-                let coeff11 = fp_chip.mul_no_carry(ctx, a[i + 6].clone(), b[j + 6].clone());
+                let coeff00 = fp_chip.mul_no_carry(ctx, &a[i], &b[j]);
+                let coeff01 = fp_chip.mul_no_carry(ctx, &a[i], &b[j + 6]);
+                let coeff10 = fp_chip.mul_no_carry(ctx, &a[i + 6], &b[j]);
+                let coeff11 = fp_chip.mul_no_carry(ctx, &a[i + 6], &b[j + 6]);
                 if i + j < a0b0_coeffs.len() {
-                    a0b0_coeffs[i + j] =
-                        fp_chip.add_no_carry(ctx, a0b0_coeffs[i + j].clone(), coeff00);
-                    a0b1_coeffs[i + j] =
-                        fp_chip.add_no_carry(ctx, a0b1_coeffs[i + j].clone(), coeff01);
-                    a1b0_coeffs[i + j] =
-                        fp_chip.add_no_carry(ctx, a1b0_coeffs[i + j].clone(), coeff10);
-                    a1b1_coeffs[i + j] =
-                        fp_chip.add_no_carry(ctx, a1b1_coeffs[i + j].clone(), coeff11);
+                    a0b0_coeffs[i + j] = fp_chip.add_no_carry(ctx, &a0b0_coeffs[i + j], coeff00);
+                    a0b1_coeffs[i + j] = fp_chip.add_no_carry(ctx, &a0b1_coeffs[i + j], coeff01);
+                    a1b0_coeffs[i + j] = fp_chip.add_no_carry(ctx, &a1b0_coeffs[i + j], coeff10);
+                    a1b1_coeffs[i + j] = fp_chip.add_no_carry(ctx, &a1b1_coeffs[i + j], coeff11);
                 } else {
                     a0b0_coeffs.push(coeff00);
                     a0b1_coeffs.push(coeff01);
@@ -178,10 +174,8 @@ where
         let mut a0b0_minus_a1b1 = Vec::with_capacity(11);
         let mut a0b1_plus_a1b0 = Vec::with_capacity(11);
         for i in 0..11 {
-            let a0b0_minus_a1b1_entry =
-                fp_chip.sub_no_carry(ctx, a0b0_coeffs[i].clone(), a1b1_coeffs[i].clone());
-            let a0b1_plus_a1b0_entry =
-                fp_chip.add_no_carry(ctx, a0b1_coeffs[i].clone(), a1b0_coeffs[i].clone());
+            let a0b0_minus_a1b1_entry = fp_chip.sub_no_carry(ctx, &a0b0_coeffs[i], &a1b1_coeffs[i]);
+            let a0b1_plus_a1b0_entry = fp_chip.add_no_carry(ctx, &a0b1_coeffs[i], &a1b0_coeffs[i]);
 
             a0b0_minus_a1b1.push(a0b0_minus_a1b1_entry);
             a0b1_plus_a1b0.push(a0b1_plus_a1b0_entry);
@@ -194,11 +188,11 @@ where
             if i < 5 {
                 let mut coeff = fp_chip.scalar_mul_and_add_no_carry(
                     ctx,
-                    a0b0_minus_a1b1[i + 6].clone(),
-                    a0b0_minus_a1b1[i].clone(),
+                    &a0b0_minus_a1b1[i + 6],
+                    &a0b0_minus_a1b1[i],
                     XI_0,
                 );
-                coeff = fp_chip.sub_no_carry(ctx, coeff, a0b1_plus_a1b0[i + 6].clone());
+                coeff = fp_chip.sub_no_carry(ctx, coeff, &a0b1_plus_a1b0[i + 6]);
                 out_coeffs.push(coeff);
             } else {
                 out_coeffs.push(a0b0_minus_a1b1[i].clone());
@@ -206,17 +200,10 @@ where
         }
         for i in 0..6 {
             if i < 5 {
-                let mut coeff = fp_chip.add_no_carry(
-                    ctx,
-                    a0b1_plus_a1b0[i].clone(),
-                    a0b0_minus_a1b1[i + 6].clone(),
-                );
-                coeff = fp_chip.scalar_mul_and_add_no_carry(
-                    ctx,
-                    a0b1_plus_a1b0[i + 6].clone(),
-                    coeff,
-                    XI_0,
-                );
+                let mut coeff =
+                    fp_chip.add_no_carry(ctx, &a0b1_plus_a1b0[i], &a0b0_minus_a1b1[i + 6]);
+                coeff =
+                    fp_chip.scalar_mul_and_add_no_carry(ctx, &a0b1_plus_a1b0[i + 6], coeff, XI_0);
                 out_coeffs.push(coeff);
             } else {
                 out_coeffs.push(a0b1_plus_a1b0[i].clone());

--- a/halo2-ecc/src/fields/fp12.rs
+++ b/halo2-ecc/src/fields/fp12.rs
@@ -1,12 +1,14 @@
-use super::{FieldChip, FieldExtConstructor, FieldExtPoint, PrimeField, PrimeFieldChip};
-use crate::halo2_proofs::arithmetic::Field;
-use halo2_base::{
-    gates::{GateInstructions, RangeInstructions},
-    utils::fe_to_biguint,
-    AssignedValue, Context,
-};
-use num_bigint::{BigInt, BigUint};
 use std::marker::PhantomData;
+
+use halo2_base::{utils::modulus, AssignedValue, Context};
+use num_bigint::BigUint;
+
+use crate::impl_field_ext_chip_common;
+
+use super::{
+    vector::{FieldVector, FieldVectorChip},
+    FieldChip, FieldExtConstructor, PrimeField, PrimeFieldChip,
+};
 
 /// Represent Fp12 point as FqPoint with degree = 12
 /// `Fp12 = Fp2[w] / (w^6 - u - xi)`
@@ -15,264 +17,155 @@ use std::marker::PhantomData;
 /// This means we store an Fp12 point as `\sum_{i = 0}^6 (a_{i0} + a_{i1} * u) * w^i`
 /// This is encoded in an FqPoint of degree 12 as `(a_{00}, ..., a_{50}, a_{01}, ..., a_{51})`
 #[derive(Clone, Copy, Debug)]
-pub struct Fp12Chip<'a, F: PrimeField, FpChip: PrimeFieldChip<F>, Fp12: Field, const XI_0: i64>
-where
-    FpChip::FieldType: PrimeField,
-{
-    // for historical reasons, leaving this as a reference
-    // for the current implementation we could also just use the de-referenced version: `fp_chip: FpChip`
-    pub fp_chip: &'a FpChip,
-    _f: PhantomData<F>,
-    _fp12: PhantomData<Fp12>,
-}
+pub struct Fp12Chip<'a, F: PrimeField, FpChip: FieldChip<F>, Fp12, const XI_0: i64>(
+    pub FieldVectorChip<'a, F, FpChip>,
+    PhantomData<Fp12>,
+);
 
 impl<'a, F, FpChip, Fp12, const XI_0: i64> Fp12Chip<'a, F, FpChip, Fp12, XI_0>
 where
     F: PrimeField,
     FpChip: PrimeFieldChip<F>,
     FpChip::FieldType: PrimeField,
-    Fp12: Field + FieldExtConstructor<FpChip::FieldType, 12>,
+    Fp12: ff::Field,
 {
     /// User must construct an `FpChip` first using a config. This is intended so everything shares a single `FlexGateChip`, which is needed for the column allocation to work.
     pub fn new(fp_chip: &'a FpChip) -> Self {
-        Self { fp_chip, _f: PhantomData, _fp12: PhantomData }
+        assert_eq!(
+            modulus::<FpChip::FieldType>() % 4usize,
+            BigUint::from(3u64),
+            "p must be 3 (mod 4) for the polynomial u^2 + 1 to be irreducible"
+        );
+        Self(FieldVectorChip::new(fp_chip), PhantomData)
+    }
+
+    pub fn fp_chip(&self) -> &FpChip {
+        self.0.fp_chip
     }
 
     pub fn fp2_mul_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-        fp2_pt: &FieldExtPoint<FpChip::FieldPoint>,
-    ) -> FieldExtPoint<FpChip::FieldPoint> {
-        assert_eq!(a.coeffs.len(), 12);
-        assert_eq!(fp2_pt.coeffs.len(), 2);
+        fp12_pt: FieldVector<FpChip::UnsafeFieldPoint>,
+        fp2_pt: FieldVector<FpChip::UnsafeFieldPoint>,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint> {
+        let fp12_pt = fp12_pt.0;
+        let fp2_pt = fp2_pt.0;
+        assert_eq!(fp12_pt.len(), 12);
+        assert_eq!(fp2_pt.len(), 2);
 
+        let fp_chip = self.fp_chip();
         let mut out_coeffs = Vec::with_capacity(12);
         for i in 0..6 {
-            let coeff1 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i], &fp2_pt.coeffs[0]);
-            let coeff2 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i + 6], &fp2_pt.coeffs[1]);
-            let coeff = self.fp_chip.sub_no_carry(ctx, &coeff1, &coeff2);
+            let coeff1 = fp_chip.mul_no_carry(ctx, fp12_pt[i].clone(), fp2_pt[0].clone());
+            let coeff2 = fp_chip.mul_no_carry(ctx, fp12_pt[i + 6].clone(), fp2_pt[1].clone());
+            let coeff = fp_chip.sub_no_carry(ctx, coeff1, coeff2);
             out_coeffs.push(coeff);
         }
         for i in 0..6 {
-            let coeff1 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i + 6], &fp2_pt.coeffs[0]);
-            let coeff2 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i], &fp2_pt.coeffs[1]);
-            let coeff = self.fp_chip.add_no_carry(ctx, &coeff1, &coeff2);
+            let coeff1 = fp_chip.mul_no_carry(ctx, fp12_pt[i + 6].clone(), fp2_pt[0].clone());
+            let coeff2 = fp_chip.mul_no_carry(ctx, fp12_pt[i].clone(), fp2_pt[1].clone());
+            let coeff = fp_chip.add_no_carry(ctx, coeff1, coeff2);
             out_coeffs.push(coeff);
         }
-        FieldExtPoint::construct(out_coeffs)
+        FieldVector(out_coeffs)
     }
 
     // for \sum_i (a_i + b_i u) w^i, returns \sum_i (-1)^i (a_i + b_i u) w^i
     pub fn conjugate(
         &self,
         ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-    ) -> FieldExtPoint<FpChip::FieldPoint> {
-        assert_eq!(a.coeffs.len(), 12);
+        a: FieldVector<FpChip::FieldPoint>,
+    ) -> FieldVector<FpChip::FieldPoint> {
+        let a = a.0;
+        assert_eq!(a.len(), 12);
 
         let coeffs = a
-            .coeffs
-            .iter()
+            .into_iter()
             .enumerate()
-            .map(|(i, c)| if i % 2 == 0 { c.clone() } else { self.fp_chip.negate(ctx, c) })
+            .map(|(i, c)| if i % 2 == 0 { c } else { self.fp_chip().negate(ctx, c) })
             .collect();
-        FieldExtPoint::construct(coeffs)
+        FieldVector(coeffs)
     }
 }
 
-/// multiply (a0 + a1 * u) * (XI0 + u) without carry
+/// multiply Fp2 elts: (a0 + a1 * u) * (XI0 + u) without carry
+///
+/// # Assumptions
+/// * `a` is `Fp2` point represented as `FieldVector` with degree = 2
 pub fn mul_no_carry_w6<F: PrimeField, FC: FieldChip<F>, const XI_0: i64>(
     fp_chip: &FC,
     ctx: &mut Context<F>,
-    a: &FieldExtPoint<FC::FieldPoint>,
-) -> FieldExtPoint<FC::FieldPoint> {
-    assert_eq!(a.coeffs.len(), 2);
-    let (a0, a1) = (&a.coeffs[0], &a.coeffs[1]);
+    a: FieldVector<FC::UnsafeFieldPoint>,
+) -> FieldVector<FC::UnsafeFieldPoint> {
+    let [a0, a1]: [_; 2] = a.0.try_into().unwrap();
     // (a0 + a1 u) * (XI_0 + u) = (a0 * XI_0 - a1) + (a1 * XI_0 + a0) u     with u^2 = -1
     // This should fit in the overflow representation if limb_bits is large enough
-    let a0_xi0 = fp_chip.scalar_mul_no_carry(ctx, a0, XI_0);
-    let out0_0_nocarry = fp_chip.sub_no_carry(ctx, &a0_xi0, a1);
+    let a0_xi0 = fp_chip.scalar_mul_no_carry(ctx, a0.clone(), XI_0);
+    let out0_0_nocarry = fp_chip.sub_no_carry(ctx, a0_xi0, a1.clone());
     let out0_1_nocarry = fp_chip.scalar_mul_and_add_no_carry(ctx, a1, a0, XI_0);
-    FieldExtPoint::construct(vec![out0_0_nocarry, out0_1_nocarry])
+    FieldVector(vec![out0_0_nocarry, out0_1_nocarry])
 }
 
 // a lot of this is common to any field extension (lots of for loops), but due to the way rust traits work, it is hard to create a common generic trait that does this. The main problem is that if you had a `FieldExtCommon` trait and wanted to implement `FieldChip` for anything with `FieldExtCommon`, rust will stop you because someone could implement `FieldExtCommon` and `FieldChip` for the same type, causing a conflict.
+// partially solved using macro
+
 impl<'a, F, FpChip, Fp12, const XI_0: i64> FieldChip<F> for Fp12Chip<'a, F, FpChip, Fp12, XI_0>
 where
     F: PrimeField,
-    FpChip: PrimeFieldChip<F, WitnessType = BigInt, ConstantType = BigUint>,
+    FpChip: PrimeFieldChip<F>,
     FpChip::FieldType: PrimeField,
-    Fp12: Field + FieldExtConstructor<FpChip::FieldType, 12>,
+    Fp12: ff::Field + FieldExtConstructor<FpChip::FieldType, 12>,
+    FieldVector<FpChip::UnsafeFieldPoint>: From<FieldVector<FpChip::FieldPoint>>,
+    FieldVector<FpChip::FieldPoint>: From<FieldVector<FpChip::ReducedFieldPoint>>,
 {
     const PRIME_FIELD_NUM_BITS: u32 = FpChip::FieldType::NUM_BITS;
-    type ConstantType = Fp12;
-    type WitnessType = Vec<BigInt>;
-    type FieldPoint = FieldExtPoint<FpChip::FieldPoint>;
+    type UnsafeFieldPoint = FieldVector<FpChip::UnsafeFieldPoint>;
+    type FieldPoint = FieldVector<FpChip::FieldPoint>;
+    type ReducedFieldPoint = FieldVector<FpChip::ReducedFieldPoint>;
     type FieldType = Fp12;
     type RangeChip = FpChip::RangeChip;
 
-    fn native_modulus(&self) -> &BigUint {
-        self.fp_chip.native_modulus()
-    }
-    fn range(&self) -> &Self::RangeChip {
-        self.fp_chip.range()
-    }
-
-    fn limb_bits(&self) -> usize {
-        self.fp_chip.limb_bits()
-    }
-
-    fn get_assigned_value(&self, x: &Self::FieldPoint) -> Fp12 {
-        assert_eq!(x.coeffs.len(), 12);
-        let values =
-            x.coeffs.iter().map(|v| self.fp_chip.get_assigned_value(v)).collect::<Vec<_>>();
+    fn get_assigned_value(&self, x: &Self::UnsafeFieldPoint) -> Fp12 {
+        assert_eq!(x.0.len(), 12);
+        let values = x.0.iter().map(|v| self.fp_chip().get_assigned_value(v)).collect::<Vec<_>>();
         Fp12::new(values.try_into().unwrap())
-    }
-
-    fn fe_to_constant(x: Self::FieldType) -> Self::ConstantType {
-        x
-    }
-    fn fe_to_witness(x: &Fp12) -> Vec<BigInt> {
-        x.coeffs().iter().map(|c| BigInt::from(fe_to_biguint(c))).collect()
-    }
-
-    fn load_private(&self, ctx: &mut Context<F>, coeffs: Vec<BigInt>) -> Self::FieldPoint {
-        assert_eq!(coeffs.len(), 12);
-        let mut assigned_coeffs = Vec::with_capacity(12);
-        for a in coeffs {
-            let assigned_coeff = self.fp_chip.load_private(ctx, a.clone());
-            assigned_coeffs.push(assigned_coeff);
-        }
-        Self::FieldPoint::construct(assigned_coeffs)
-    }
-
-    fn load_constant(&self, ctx: &mut Context<F>, c: Fp12) -> Self::FieldPoint {
-        let mut assigned_coeffs = Vec::with_capacity(12);
-        for a in &c.coeffs() {
-            let assigned_coeff = self.fp_chip.load_constant(ctx, fe_to_biguint(a));
-            assigned_coeffs.push(assigned_coeff);
-        }
-        Self::FieldPoint::construct(assigned_coeffs)
-    }
-
-    // signed overflow BigInt functions
-    fn add_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), b.coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.add_no_carry(ctx, &a.coeffs[i], &b.coeffs[i]);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn add_constant_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        c: Self::ConstantType,
-    ) -> Self::FieldPoint {
-        let c_coeffs = c.coeffs();
-        assert_eq!(a.coeffs.len(), c_coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for (a, c) in a.coeffs.iter().zip(c_coeffs.into_iter()) {
-            let coeff = self.fp_chip.add_constant_no_carry(ctx, a, FpChip::fe_to_constant(c));
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn sub_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), b.coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.sub_no_carry(ctx, &a.coeffs[i], &b.coeffs[i]);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn negate(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for a_coeff in &a.coeffs {
-            let out_coeff = self.fp_chip.negate(ctx, a_coeff);
-            out_coeffs.push(out_coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn scalar_mul_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        c: i64,
-    ) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.scalar_mul_no_carry(ctx, &a.coeffs[i], c);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn scalar_mul_and_add_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-        c: i64,
-    ) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff =
-                self.fp_chip.scalar_mul_and_add_no_carry(ctx, &a.coeffs[i], &b.coeffs[i], c);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
     }
 
     // w^6 = u + xi for xi = 9
     fn mul_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), 12);
-        assert_eq!(b.coeffs.len(), 12);
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
+    ) -> Self::UnsafeFieldPoint {
+        let a = a.into().0;
+        let b = b.into().0;
+        assert_eq!(a.len(), 12);
+        assert_eq!(b.len(), 12);
 
+        let fp_chip = self.fp_chip();
         // a = \sum_{i = 0}^5 (a_i * w^i + a_{i + 6} * w^i * u)
         // b = \sum_{i = 0}^5 (b_i * w^i + b_{i + 6} * w^i * u)
-        let mut a0b0_coeffs = Vec::with_capacity(11);
-        let mut a0b1_coeffs = Vec::with_capacity(11);
-        let mut a1b0_coeffs = Vec::with_capacity(11);
-        let mut a1b1_coeffs = Vec::with_capacity(11);
+        let mut a0b0_coeffs: Vec<FpChip::UnsafeFieldPoint> = Vec::with_capacity(11);
+        let mut a0b1_coeffs: Vec<FpChip::UnsafeFieldPoint> = Vec::with_capacity(11);
+        let mut a1b0_coeffs: Vec<FpChip::UnsafeFieldPoint> = Vec::with_capacity(11);
+        let mut a1b1_coeffs: Vec<FpChip::UnsafeFieldPoint> = Vec::with_capacity(11);
         for i in 0..6 {
             for j in 0..6 {
-                let coeff00 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i], &b.coeffs[j]);
-                let coeff01 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i], &b.coeffs[j + 6]);
-                let coeff10 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i + 6], &b.coeffs[j]);
-                let coeff11 = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i + 6], &b.coeffs[j + 6]);
+                let coeff00 = fp_chip.mul_no_carry(ctx, a[i].clone(), b[j].clone());
+                let coeff01 = fp_chip.mul_no_carry(ctx, a[i].clone(), b[j + 6].clone());
+                let coeff10 = fp_chip.mul_no_carry(ctx, a[i + 6].clone(), b[j].clone());
+                let coeff11 = fp_chip.mul_no_carry(ctx, a[i + 6].clone(), b[j + 6].clone());
                 if i + j < a0b0_coeffs.len() {
                     a0b0_coeffs[i + j] =
-                        self.fp_chip.add_no_carry(ctx, &a0b0_coeffs[i + j], &coeff00);
+                        fp_chip.add_no_carry(ctx, a0b0_coeffs[i + j].clone(), coeff00);
                     a0b1_coeffs[i + j] =
-                        self.fp_chip.add_no_carry(ctx, &a0b1_coeffs[i + j], &coeff01);
+                        fp_chip.add_no_carry(ctx, a0b1_coeffs[i + j].clone(), coeff01);
                     a1b0_coeffs[i + j] =
-                        self.fp_chip.add_no_carry(ctx, &a1b0_coeffs[i + j], &coeff10);
+                        fp_chip.add_no_carry(ctx, a1b0_coeffs[i + j].clone(), coeff10);
                     a1b1_coeffs[i + j] =
-                        self.fp_chip.add_no_carry(ctx, &a1b1_coeffs[i + j], &coeff11);
+                        fp_chip.add_no_carry(ctx, a1b1_coeffs[i + j].clone(), coeff11);
                 } else {
                     a0b0_coeffs.push(coeff00);
                     a0b1_coeffs.push(coeff01);
@@ -286,9 +179,9 @@ where
         let mut a0b1_plus_a1b0 = Vec::with_capacity(11);
         for i in 0..11 {
             let a0b0_minus_a1b1_entry =
-                self.fp_chip.sub_no_carry(ctx, &a0b0_coeffs[i], &a1b1_coeffs[i]);
+                fp_chip.sub_no_carry(ctx, a0b0_coeffs[i].clone(), a1b1_coeffs[i].clone());
             let a0b1_plus_a1b0_entry =
-                self.fp_chip.add_no_carry(ctx, &a0b1_coeffs[i], &a1b0_coeffs[i]);
+                fp_chip.add_no_carry(ctx, a0b1_coeffs[i].clone(), a1b0_coeffs[i].clone());
 
             a0b0_minus_a1b1.push(a0b0_minus_a1b1_entry);
             a0b1_plus_a1b0.push(a0b1_plus_a1b0_entry);
@@ -299,13 +192,13 @@ where
         let mut out_coeffs = Vec::with_capacity(12);
         for i in 0..6 {
             if i < 5 {
-                let mut coeff = self.fp_chip.scalar_mul_and_add_no_carry(
+                let mut coeff = fp_chip.scalar_mul_and_add_no_carry(
                     ctx,
-                    &a0b0_minus_a1b1[i + 6],
-                    &a0b0_minus_a1b1[i],
+                    a0b0_minus_a1b1[i + 6].clone(),
+                    a0b0_minus_a1b1[i].clone(),
                     XI_0,
                 );
-                coeff = self.fp_chip.sub_no_carry(ctx, &coeff, &a0b1_plus_a1b0[i + 6]);
+                coeff = fp_chip.sub_no_carry(ctx, coeff, a0b1_plus_a1b0[i + 6].clone());
                 out_coeffs.push(coeff);
             } else {
                 out_coeffs.push(a0b0_minus_a1b1[i].clone());
@@ -313,12 +206,15 @@ where
         }
         for i in 0..6 {
             if i < 5 {
-                let mut coeff =
-                    self.fp_chip.add_no_carry(ctx, &a0b1_plus_a1b0[i], &a0b0_minus_a1b1[i + 6]);
-                coeff = self.fp_chip.scalar_mul_and_add_no_carry(
+                let mut coeff = fp_chip.add_no_carry(
                     ctx,
-                    &a0b1_plus_a1b0[i + 6],
-                    &coeff,
+                    a0b1_plus_a1b0[i].clone(),
+                    a0b0_minus_a1b1[i + 6].clone(),
+                );
+                coeff = fp_chip.scalar_mul_and_add_no_carry(
+                    ctx,
+                    a0b1_plus_a1b0[i + 6].clone(),
+                    coeff,
                     XI_0,
                 );
                 out_coeffs.push(coeff);
@@ -326,119 +222,10 @@ where
                 out_coeffs.push(a0b1_plus_a1b0[i].clone());
             }
         }
-        Self::FieldPoint::construct(out_coeffs)
+        FieldVector(out_coeffs)
     }
 
-    fn check_carry_mod_to_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) {
-        for coeff in &a.coeffs {
-            self.fp_chip.check_carry_mod_to_zero(ctx, coeff);
-        }
-    }
-
-    fn carry_mod(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.carry_mod(ctx, a_coeff);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn range_check(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, max_bits: usize) {
-        for a_coeff in &a.coeffs {
-            self.fp_chip.range_check(ctx, a_coeff, max_bits);
-        }
-    }
-
-    fn enforce_less_than(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) {
-        for a_coeff in &a.coeffs {
-            self.fp_chip.enforce_less_than(ctx, a_coeff)
-        }
-    }
-
-    fn is_soft_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_soft_zero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.fp_chip.range().gate().and(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_soft_nonzero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_soft_nonzero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.gate().or(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_zero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.gate().and(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_equal(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> AssignedValue<F> {
-        let mut acc = None;
-        for (a_coeff, b_coeff) in a.coeffs.iter().zip(b.coeffs.iter()) {
-            let coeff = self.fp_chip.is_equal(ctx, a_coeff, b_coeff);
-            if let Some(c) = acc {
-                acc = Some(self.gate().and(ctx, coeff, c));
-            } else {
-                acc = Some(coeff);
-            }
-        }
-        acc.unwrap()
-    }
-
-    fn is_equal_unenforced(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> AssignedValue<F> {
-        let mut acc = None;
-        for (a_coeff, b_coeff) in a.coeffs.iter().zip(b.coeffs.iter()) {
-            let coeff = self.fp_chip.is_equal_unenforced(ctx, a_coeff, b_coeff);
-            if let Some(c) = acc {
-                acc = Some(self.gate().and(ctx, coeff, c));
-            } else {
-                acc = Some(coeff);
-            }
-        }
-        acc.unwrap()
-    }
-
-    fn assert_equal(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, b: &Self::FieldPoint) {
-        for (a_coeff, b_coeff) in a.coeffs.iter().zip(b.coeffs.iter()) {
-            self.fp_chip.assert_equal(ctx, a_coeff, b_coeff);
-        }
-    }
+    impl_field_ext_chip_common!();
 }
 
 mod bn254 {

--- a/halo2-ecc/src/fields/fp2.rs
+++ b/halo2-ecc/src/fields/fp2.rs
@@ -1,94 +1,66 @@
-use super::{
-    FieldChip, FieldExtConstructor, FieldExtPoint, PrimeField, PrimeFieldChip, Selectable,
-};
-use crate::halo2_proofs::arithmetic::Field;
-use halo2_base::{gates::GateInstructions, utils::fe_to_biguint, AssignedValue, Context};
-use num_bigint::{BigInt, BigUint};
+use std::fmt::Debug;
 use std::marker::PhantomData;
 
-/// Represent Fp2 point as `FieldExtPoint` with degree = 2
+use halo2_base::{utils::modulus, AssignedValue, Context};
+use num_bigint::BigUint;
+
+use crate::impl_field_ext_chip_common;
+
+use super::{
+    vector::{FieldVector, FieldVectorChip},
+    FieldChip, FieldExtConstructor, PrimeField, PrimeFieldChip,
+};
+
+/// Represent Fp2 point as `FieldVector` with degree = 2
 /// `Fp2 = Fp[u] / (u^2 + 1)`
 /// This implementation assumes p = 3 (mod 4) in order for the polynomial u^2 + 1 to be irreducible over Fp; i.e., in order for -1 to not be a square (quadratic residue) in Fp
 /// This means we store an Fp2 point as `a_0 + a_1 * u` where `a_0, a_1 in Fp`
 #[derive(Clone, Copy, Debug)]
-pub struct Fp2Chip<'a, F: PrimeField, FpChip: PrimeFieldChip<F>, Fp2: Field>
-where
-    FpChip::FieldType: PrimeField,
-{
-    // for historical reasons, leaving this as a reference
-    // for the current implementation we could also just use the de-referenced version: `fp_chip: FpChip`
-    pub fp_chip: &'a FpChip,
-    _f: PhantomData<F>,
-    _fp2: PhantomData<Fp2>,
-}
+pub struct Fp2Chip<'a, F: PrimeField, FpChip: FieldChip<F>, Fp2>(
+    pub FieldVectorChip<'a, F, FpChip>,
+    PhantomData<Fp2>,
+);
 
-impl<'a, F, FpChip, Fp2> Fp2Chip<'a, F, FpChip, Fp2>
+impl<'a, F: PrimeField, FpChip: PrimeFieldChip<F>, Fp2: ff::Field> Fp2Chip<'a, F, FpChip, Fp2>
 where
-    F: PrimeField,
-    FpChip: PrimeFieldChip<F>,
     FpChip::FieldType: PrimeField,
-    Fp2: Field + FieldExtConstructor<FpChip::FieldType, 2>,
 {
     /// User must construct an `FpChip` first using a config. This is intended so everything shares a single `FlexGateChip`, which is needed for the column allocation to work.
     pub fn new(fp_chip: &'a FpChip) -> Self {
-        Self { fp_chip, _f: PhantomData, _fp2: PhantomData }
+        assert_eq!(
+            modulus::<FpChip::FieldType>() % 4usize,
+            BigUint::from(3u64),
+            "p must be 3 (mod 4) for the polynomial u^2 + 1 to be irreducible"
+        );
+        Self(FieldVectorChip::new(fp_chip), PhantomData)
     }
 
-    pub fn fp_mul_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-        fp_point: &FpChip::FieldPoint,
-    ) -> FieldExtPoint<FpChip::FieldPoint> {
-        assert_eq!(a.coeffs.len(), 2);
-
-        let mut out_coeffs = Vec::with_capacity(2);
-        for c in &a.coeffs {
-            let coeff = self.fp_chip.mul_no_carry(ctx, c, fp_point);
-            out_coeffs.push(coeff);
-        }
-        FieldExtPoint::construct(out_coeffs)
+    pub fn fp_chip(&self) -> &FpChip {
+        self.0.fp_chip
     }
 
     pub fn conjugate(
         &self,
         ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-    ) -> FieldExtPoint<FpChip::FieldPoint> {
-        assert_eq!(a.coeffs.len(), 2);
+        a: FieldVector<FpChip::FieldPoint>,
+    ) -> FieldVector<FpChip::FieldPoint> {
+        let mut a = a.0;
+        assert_eq!(a.len(), 2);
 
-        let neg_a1 = self.fp_chip.negate(ctx, &a.coeffs[1]);
-        FieldExtPoint::construct(vec![a.coeffs[0].clone(), neg_a1])
+        let neg_a1 = self.fp_chip().negate(ctx, a.pop().unwrap());
+        FieldVector(vec![a.pop().unwrap(), neg_a1])
     }
 
     pub fn neg_conjugate(
         &self,
         ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-    ) -> FieldExtPoint<FpChip::FieldPoint> {
-        assert_eq!(a.coeffs.len(), 2);
+        a: FieldVector<FpChip::FieldPoint>,
+    ) -> FieldVector<FpChip::FieldPoint> {
+        assert_eq!(a.0.len(), 2);
+        let mut a = a.0.into_iter();
 
-        let neg_a0 = self.fp_chip.negate(ctx, &a.coeffs[0]);
-        FieldExtPoint::construct(vec![neg_a0, a.coeffs[1].clone()])
-    }
-
-    pub fn select(
-        &self,
-        ctx: &mut Context<F>,
-        a: &FieldExtPoint<FpChip::FieldPoint>,
-        b: &FieldExtPoint<FpChip::FieldPoint>,
-        sel: AssignedValue<F>,
-    ) -> FieldExtPoint<FpChip::FieldPoint>
-    where
-        FpChip: Selectable<F, Point = FpChip::FieldPoint>,
-    {
-        let coeffs: Vec<_> = a
-            .coeffs
-            .iter()
-            .zip(b.coeffs.iter())
-            .map(|(a, b)| self.fp_chip.select(ctx, a, b, sel))
-            .collect();
-        FieldExtPoint::construct(coeffs)
+        let neg_a0 = self.fp_chip().negate(ctx, a.next().unwrap());
+        FieldVector(vec![neg_a0, a.next().unwrap()])
     }
 }
 
@@ -96,268 +68,52 @@ impl<'a, F, FpChip, Fp2> FieldChip<F> for Fp2Chip<'a, F, FpChip, Fp2>
 where
     F: PrimeField,
     FpChip::FieldType: PrimeField,
-    FpChip: PrimeFieldChip<F, WitnessType = BigInt, ConstantType = BigUint>,
-    Fp2: Field + FieldExtConstructor<FpChip::FieldType, 2>,
+    FpChip: PrimeFieldChip<F>,
+    Fp2: ff::Field + FieldExtConstructor<FpChip::FieldType, 2>,
+    FieldVector<FpChip::UnsafeFieldPoint>: From<FieldVector<FpChip::FieldPoint>>,
+    FieldVector<FpChip::FieldPoint>: From<FieldVector<FpChip::ReducedFieldPoint>>,
 {
     const PRIME_FIELD_NUM_BITS: u32 = FpChip::FieldType::NUM_BITS;
-    type ConstantType = Fp2;
-    type WitnessType = Vec<BigInt>;
-    type FieldPoint = FieldExtPoint<FpChip::FieldPoint>;
+    type UnsafeFieldPoint = FieldVector<FpChip::UnsafeFieldPoint>;
+    type FieldPoint = FieldVector<FpChip::FieldPoint>;
+    type ReducedFieldPoint = FieldVector<FpChip::ReducedFieldPoint>;
     type FieldType = Fp2;
     type RangeChip = FpChip::RangeChip;
 
-    fn native_modulus(&self) -> &BigUint {
-        self.fp_chip.native_modulus()
-    }
-    fn range(&self) -> &Self::RangeChip {
-        self.fp_chip.range()
-    }
-
-    fn limb_bits(&self) -> usize {
-        self.fp_chip.limb_bits()
-    }
-
-    fn get_assigned_value(&self, x: &Self::FieldPoint) -> Fp2 {
-        debug_assert_eq!(x.coeffs.len(), 2);
-        let c0 = self.fp_chip.get_assigned_value(&x.coeffs[0]);
-        let c1 = self.fp_chip.get_assigned_value(&x.coeffs[1]);
+    fn get_assigned_value(&self, x: &Self::UnsafeFieldPoint) -> Fp2 {
+        assert_eq!(x.0.len(), 2);
+        let c0 = self.fp_chip().get_assigned_value(&x[0]);
+        let c1 = self.fp_chip().get_assigned_value(&x[1]);
         Fp2::new([c0, c1])
-    }
-
-    fn fe_to_constant(x: Fp2) -> Fp2 {
-        x
-    }
-
-    fn fe_to_witness(x: &Fp2) -> Vec<BigInt> {
-        let coeffs = x.coeffs();
-        debug_assert_eq!(coeffs.len(), 2);
-        coeffs.iter().map(|c| BigInt::from(fe_to_biguint(c))).collect()
-    }
-
-    fn load_private(&self, ctx: &mut Context<F>, coeffs: Vec<BigInt>) -> Self::FieldPoint {
-        debug_assert_eq!(coeffs.len(), 2);
-        let mut assigned_coeffs = Vec::with_capacity(2);
-        for a in coeffs {
-            let assigned_coeff = self.fp_chip.load_private(ctx, a);
-            assigned_coeffs.push(assigned_coeff);
-        }
-        Self::FieldPoint::construct(assigned_coeffs)
-    }
-
-    fn load_constant(&self, ctx: &mut Context<F>, c: Fp2) -> Self::FieldPoint {
-        let mut assigned_coeffs = Vec::with_capacity(2);
-        for a in &c.coeffs() {
-            let assigned_coeff = self.fp_chip.load_constant(ctx, fe_to_biguint(a));
-            assigned_coeffs.push(assigned_coeff);
-        }
-        Self::FieldPoint::construct(assigned_coeffs)
-    }
-
-    // signed overflow BigInt functions
-    fn add_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), b.coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.add_no_carry(ctx, &a.coeffs[i], &b.coeffs[i]);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn add_constant_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        c: Self::ConstantType,
-    ) -> Self::FieldPoint {
-        let c_coeffs = c.coeffs();
-        assert_eq!(a.coeffs.len(), c_coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for (a, c) in a.coeffs.iter().zip(c_coeffs.into_iter()) {
-            let coeff = self.fp_chip.add_constant_no_carry(ctx, a, FpChip::fe_to_constant(c));
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn sub_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), b.coeffs.len());
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.sub_no_carry(ctx, &a.coeffs[i], &b.coeffs[i]);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn negate(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for a_coeff in &a.coeffs {
-            let out_coeff = self.fp_chip.negate(ctx, a_coeff);
-            out_coeffs.push(out_coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn scalar_mul_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        c: i64,
-    ) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff = self.fp_chip.scalar_mul_no_carry(ctx, &a.coeffs[i], c);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn scalar_mul_and_add_no_carry(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-        c: i64,
-    ) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            let coeff =
-                self.fp_chip.scalar_mul_and_add_no_carry(ctx, &a.coeffs[i], &b.coeffs[i], c);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
     }
 
     fn mul_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint {
-        assert_eq!(a.coeffs.len(), b.coeffs.len());
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
+    ) -> Self::UnsafeFieldPoint {
+        let a = a.into().0;
+        let b = b.into().0;
+        assert_eq!(a.len(), 2);
+        assert_eq!(b.len(), 2);
+        let fp_chip = self.fp_chip();
         // (a_0 + a_1 * u) * (b_0 + b_1 * u) = (a_0 b_0 - a_1 b_1) + (a_0 b_1 + a_1 b_0) * u
-        let mut ab_coeffs = Vec::with_capacity(a.coeffs.len() * b.coeffs.len());
-        for i in 0..a.coeffs.len() {
-            for j in 0..b.coeffs.len() {
-                let coeff = self.fp_chip.mul_no_carry(ctx, &a.coeffs[i], &b.coeffs[j]);
+        let mut ab_coeffs = Vec::with_capacity(4);
+        for a_i in a {
+            for b_j in b.iter() {
+                let coeff = fp_chip.mul_no_carry(ctx, a_i.clone(), b_j.clone());
                 ab_coeffs.push(coeff);
             }
         }
-        let a0b0_minus_a1b1 =
-            self.fp_chip.sub_no_carry(ctx, &ab_coeffs[0], &ab_coeffs[b.coeffs.len() + 1]);
-        let a0b1_plus_a1b0 =
-            self.fp_chip.add_no_carry(ctx, &ab_coeffs[1], &ab_coeffs[b.coeffs.len()]);
+        let a0b0_minus_a1b1 = fp_chip.sub_no_carry(ctx, ab_coeffs[0].clone(), ab_coeffs[3].clone());
+        let a0b1_plus_a1b0 = fp_chip.add_no_carry(ctx, ab_coeffs[1].clone(), ab_coeffs[2].clone());
 
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        out_coeffs.push(a0b0_minus_a1b1);
-        out_coeffs.push(a0b1_plus_a1b0);
-
-        Self::FieldPoint::construct(out_coeffs)
+        FieldVector(vec![a0b0_minus_a1b1, a0b1_plus_a1b0])
     }
 
-    fn check_carry_mod_to_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) {
-        for coeff in &a.coeffs {
-            self.fp_chip.check_carry_mod_to_zero(ctx, coeff);
-        }
-    }
-
-    fn carry_mod(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint {
-        let mut out_coeffs = Vec::with_capacity(a.coeffs.len());
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.carry_mod(ctx, a_coeff);
-            out_coeffs.push(coeff);
-        }
-        Self::FieldPoint::construct(out_coeffs)
-    }
-
-    fn range_check(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, max_bits: usize) {
-        for a_coeff in &a.coeffs {
-            self.fp_chip.range_check(ctx, a_coeff, max_bits);
-        }
-    }
-
-    fn enforce_less_than(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) {
-        for a_coeff in &a.coeffs {
-            self.fp_chip.enforce_less_than(ctx, a_coeff)
-        }
-    }
-
-    fn is_soft_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_soft_zero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.gate().and(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_soft_nonzero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_soft_nonzero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.gate().or(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F> {
-        let mut prev = None;
-        for a_coeff in &a.coeffs {
-            let coeff = self.fp_chip.is_zero(ctx, a_coeff);
-            if let Some(p) = prev {
-                let new = self.gate().and(ctx, coeff, p);
-                prev = Some(new);
-            } else {
-                prev = Some(coeff);
-            }
-        }
-        prev.unwrap()
-    }
-
-    fn is_equal_unenforced(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> AssignedValue<F> {
-        let mut acc = None;
-        for (a_coeff, b_coeff) in a.coeffs.iter().zip(b.coeffs.iter()) {
-            let coeff = self.fp_chip.is_equal_unenforced(ctx, a_coeff, b_coeff);
-            if let Some(c) = acc {
-                acc = Some(self.gate().and(ctx, coeff, c));
-            } else {
-                acc = Some(coeff);
-            }
-        }
-        acc.unwrap()
-    }
-
-    fn assert_equal(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, b: &Self::FieldPoint) {
-        for (a_coeff, b_coeff) in a.coeffs.iter().zip(b.coeffs.iter()) {
-            self.fp_chip.assert_equal(ctx, a_coeff, b_coeff)
-        }
-    }
+    // ========= inherited from FieldVectorChip =========
+    impl_field_ext_chip_common!();
 }
 
 mod bn254 {

--- a/halo2-ecc/src/fields/fp2.rs
+++ b/halo2-ecc/src/fields/fp2.rs
@@ -102,12 +102,12 @@ where
         let mut ab_coeffs = Vec::with_capacity(4);
         for a_i in a {
             for b_j in b.iter() {
-                let coeff = fp_chip.mul_no_carry(ctx, a_i.clone(), b_j.clone());
+                let coeff = fp_chip.mul_no_carry(ctx, &a_i, b_j);
                 ab_coeffs.push(coeff);
             }
         }
-        let a0b0_minus_a1b1 = fp_chip.sub_no_carry(ctx, ab_coeffs[0].clone(), ab_coeffs[3].clone());
-        let a0b1_plus_a1b0 = fp_chip.add_no_carry(ctx, ab_coeffs[1].clone(), ab_coeffs[2].clone());
+        let a0b0_minus_a1b1 = fp_chip.sub_no_carry(ctx, &ab_coeffs[0], &ab_coeffs[3]);
+        let a0b1_plus_a1b0 = fp_chip.add_no_carry(ctx, &ab_coeffs[1], &ab_coeffs[2]);
 
         FieldVector(vec![a0b0_minus_a1b1, a0b1_plus_a1b0])
     }

--- a/halo2-ecc/src/fields/mod.rs
+++ b/halo2-ecc/src/fields/mod.rs
@@ -11,37 +11,42 @@ use std::fmt::Debug;
 pub mod fp;
 pub mod fp12;
 pub mod fp2;
+pub mod vector;
 
 #[cfg(test)]
 mod tests;
 
 pub trait PrimeField = BigPrimeField;
 
-#[derive(Clone, Debug)]
-pub struct FieldExtPoint<FieldPoint: Clone + Debug> {
-    // `F_q` field extension of `F_p` where `q = p^degree`
-    // An `F_q` point consists of `degree` number of `F_p` points
-    // The `F_p` points are stored as `FieldPoint`s
-
-    // We do not specify the irreducible `F_p` polynomial used to construct `F_q` here - that is implementation specific
-    pub coeffs: Vec<FieldPoint>,
-    // `degree = coeffs.len()`
-}
-
-impl<FieldPoint: Clone + Debug> FieldExtPoint<FieldPoint> {
-    pub fn construct(coeffs: Vec<FieldPoint>) -> Self {
-        Self { coeffs }
-    }
-}
-
-/// Common functionality for finite field chips
-pub trait FieldChip<F: PrimeField>: Clone + Debug + Send + Sync {
+/// Trait for common functionality for finite field chips.
+/// Primarily intended to emulate a "non-native" finite field using "native" values in a prime field `F`.
+/// Most functions are designed for the case when the non-native field is larger than the native field, but
+/// the trait can still be implemented and used in other cases.
+pub trait FieldChip<F: PrimeField>: Clone + Send + Sync {
     const PRIME_FIELD_NUM_BITS: u32;
 
-    type ConstantType: Debug;
-    type WitnessType: Debug;
-    type FieldPoint: Clone + Debug + Send + Sync;
-    // a type implementing `Field` trait to help with witness generation (for example with inverse)
+    /// A representation of a field element that is used for intermediate computations.
+    /// The representation can have "overflows" (e.g., overflow limbs or negative limbs).
+    type UnsafeFieldPoint: Clone
+        + Debug
+        + Send
+        + Sync
+        + From<Self::FieldPoint>
+        + for<'a> From<&'a Self::UnsafeFieldPoint>
+        + for<'a> From<&'a Self::FieldPoint>; // Cloning all the time impacts readability, so we allow references to be cloned into owned values
+
+    /// The "proper" representation of a field element. Allowed to be a non-unique representation of a field element (e.g., can be greater than modulus)
+    type FieldPoint: Clone
+        + Debug
+        + Send
+        + Sync
+        + From<Self::ReducedFieldPoint>
+        + for<'a> From<&'a Self::FieldPoint>;
+
+    /// A proper representation of field elements that guarantees a unique representation of each field element. Typically this means Uints that are less than the modulus.
+    type ReducedFieldPoint: Clone + Debug + Send + Sync;
+
+    /// A type implementing `Field` trait to help with witness generation (for example with inverse)
     type FieldType: Field;
     type RangeChip: RangeInstructions<F>;
 
@@ -52,81 +57,124 @@ pub trait FieldChip<F: PrimeField>: Clone + Debug + Send + Sync {
     fn range(&self) -> &Self::RangeChip;
     fn limb_bits(&self) -> usize;
 
-    fn get_assigned_value(&self, x: &Self::FieldPoint) -> Self::FieldType;
+    fn get_assigned_value(&self, x: &Self::UnsafeFieldPoint) -> Self::FieldType;
 
-    fn fe_to_constant(x: Self::FieldType) -> Self::ConstantType;
-    fn fe_to_witness(x: &Self::FieldType) -> Self::WitnessType;
+    /// Assigns `fe` as private witness. Note that the witness may **not** be constrained to be a unique representation of the field element `fe`.
+    fn load_private(&self, ctx: &mut Context<F>, fe: Self::FieldType) -> Self::FieldPoint;
 
-    fn load_private(&self, ctx: &mut Context<F>, coeffs: Self::WitnessType) -> Self::FieldPoint;
+    /// Assigns `fe` as private witness and contrains the witness to be in reduced form.
+    fn load_private_reduced(
+        &self,
+        ctx: &mut Context<F>,
+        fe: Self::FieldType,
+    ) -> Self::ReducedFieldPoint {
+        let fe = self.load_private(ctx, fe);
+        self.enforce_less_than(ctx, fe)
+    }
 
-    fn load_constant(&self, ctx: &mut Context<F>, coeffs: Self::ConstantType) -> Self::FieldPoint;
+    /// Assigns `fe` as constant.
+    fn load_constant(&self, ctx: &mut Context<F>, fe: Self::FieldType) -> Self::FieldPoint;
 
     fn add_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint;
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
+    ) -> Self::UnsafeFieldPoint;
 
     /// output: `a + c`
     fn add_constant_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        c: Self::ConstantType,
-    ) -> Self::FieldPoint;
+        a: impl Into<Self::UnsafeFieldPoint>,
+        c: Self::FieldType,
+    ) -> Self::UnsafeFieldPoint;
 
     fn sub_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint;
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
+    ) -> Self::UnsafeFieldPoint;
 
-    fn negate(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint;
+    fn negate(&self, ctx: &mut Context<F>, a: Self::FieldPoint) -> Self::FieldPoint;
 
     /// a * c
     fn scalar_mul_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
+        a: impl Into<Self::UnsafeFieldPoint>,
         c: i64,
-    ) -> Self::FieldPoint;
+    ) -> Self::UnsafeFieldPoint;
 
     /// a * c + b
     fn scalar_mul_and_add_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
         c: i64,
-    ) -> Self::FieldPoint;
+    ) -> Self::UnsafeFieldPoint;
 
     fn mul_no_carry(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> Self::FieldPoint;
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
+    ) -> Self::UnsafeFieldPoint;
 
-    fn check_carry_mod_to_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint);
+    fn check_carry_mod_to_zero(&self, ctx: &mut Context<F>, a: Self::UnsafeFieldPoint);
 
-    fn carry_mod(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> Self::FieldPoint;
+    fn carry_mod(&self, ctx: &mut Context<F>, a: Self::UnsafeFieldPoint) -> Self::FieldPoint;
 
-    fn range_check(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, max_bits: usize);
+    fn range_check(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl Into<Self::UnsafeFieldPoint>,
+        max_bits: usize,
+    );
 
-    fn enforce_less_than(&self, ctx: &mut Context<F>, a: &Self::FieldPoint);
+    /// Constrains that `a` is a reduced representation and returns the wrapped `a`.
+    fn enforce_less_than(
+        &self,
+        ctx: &mut Context<F>,
+        a: Self::FieldPoint,
+    ) -> Self::ReducedFieldPoint;
 
     // Returns 1 iff the underlying big integer for `a` is 0. Otherwise returns 0.
     // For field extensions, checks coordinate-wise.
-    fn is_soft_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F>;
+    fn is_soft_zero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl Into<Self::FieldPoint>,
+    ) -> AssignedValue<F>;
 
     // Constrains that the underlying big integer is in [0, p - 1].
     // Then returns 1 iff the underlying big integer for `a` is 0. Otherwise returns 0.
     // For field extensions, checks coordinate-wise.
-    fn is_soft_nonzero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F>;
+    fn is_soft_nonzero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl Into<Self::FieldPoint>,
+    ) -> AssignedValue<F>;
 
-    fn is_zero(&self, ctx: &mut Context<F>, a: &Self::FieldPoint) -> AssignedValue<F>;
+    fn is_zero(&self, ctx: &mut Context<F>, a: impl Into<Self::FieldPoint>) -> AssignedValue<F>;
+
+    fn is_equal_unenforced(
+        &self,
+        ctx: &mut Context<F>,
+        a: Self::ReducedFieldPoint,
+        b: Self::ReducedFieldPoint,
+    ) -> AssignedValue<F>;
+
+    fn assert_equal(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl Into<Self::FieldPoint>,
+        b: impl Into<Self::FieldPoint>,
+    );
+
+    // =========== default implementations =============
 
     // assuming `a, b` have been range checked to be a proper BigInt
     // constrain the witnesses `a, b` to be `< p`
@@ -134,67 +182,64 @@ pub trait FieldChip<F: PrimeField>: Clone + Debug + Send + Sync {
     fn is_equal(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::FieldPoint>,
+        b: impl Into<Self::FieldPoint>,
     ) -> AssignedValue<F> {
-        self.enforce_less_than(ctx, a);
-        self.enforce_less_than(ctx, b);
+        let a = self.enforce_less_than(ctx, a.into());
+        let b = self.enforce_less_than(ctx, b.into());
         // a.native and b.native are derived from `a.truncation, b.truncation`, so no need to check if they're equal
         self.is_equal_unenforced(ctx, a, b)
     }
 
-    fn is_equal_unenforced(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
-    ) -> AssignedValue<F>;
-
-    fn assert_equal(&self, ctx: &mut Context<F>, a: &Self::FieldPoint, b: &Self::FieldPoint);
-
+    /// If using `UnsafeFieldPoint`, make sure multiplication does not cause overflow.
     fn mul(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
     ) -> Self::FieldPoint {
         let no_carry = self.mul_no_carry(ctx, a, b);
-        self.carry_mod(ctx, &no_carry)
+        self.carry_mod(ctx, no_carry)
     }
 
     /// Constrains that `b` is nonzero as a field element and then returns `a / b`.
     fn divide(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::FieldPoint>,
+        b: impl Into<Self::FieldPoint>,
     ) -> Self::FieldPoint {
-        let b_is_zero = self.is_zero(ctx, b);
+        let b = b.into();
+        let b_is_zero = self.is_zero(ctx, b.clone());
         self.gate().assert_is_const(ctx, &b_is_zero, &F::zero());
 
-        self.divide_unsafe(ctx, a, b)
+        self.divide_unsafe(ctx, a.into(), b)
     }
 
     /// Returns `a / b` without constraining `b` to be nonzero.
     ///
     /// Warning: undefined behavior when `b` is zero.
+    ///
+    /// `a, b` must be such that `quot * b - a` without carry does not overflow, where `quot` is the output.
     fn divide_unsafe(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
     ) -> Self::FieldPoint {
-        let a_val = self.get_assigned_value(a);
-        let b_val = self.get_assigned_value(b);
+        let a = a.into();
+        let b = b.into();
+        let a_val = self.get_assigned_value(&a);
+        let b_val = self.get_assigned_value(&b);
         let b_inv: Self::FieldType = Option::from(b_val.invert()).unwrap_or_default();
         let quot_val = a_val * b_inv;
 
-        let quot = self.load_private(ctx, Self::fe_to_witness(&quot_val));
+        let quot = self.load_private(ctx, quot_val);
 
         // constrain quot * b - a = 0 mod p
-        let quot_b = self.mul_no_carry(ctx, &quot, b);
-        let quot_constraint = self.sub_no_carry(ctx, &quot_b, a);
-        self.check_carry_mod_to_zero(ctx, &quot_constraint);
+        let quot_b = self.mul_no_carry(ctx, quot.clone(), b);
+        let quot_constraint = self.sub_no_carry(ctx, quot_b, a);
+        self.check_carry_mod_to_zero(ctx, quot_constraint);
 
         quot
     }
@@ -203,13 +248,14 @@ pub trait FieldChip<F: PrimeField>: Clone + Debug + Send + Sync {
     fn neg_divide(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::FieldPoint>,
+        b: impl Into<Self::FieldPoint>,
     ) -> Self::FieldPoint {
-        let b_is_zero = self.is_zero(ctx, b);
+        let b = b.into();
+        let b_is_zero = self.is_zero(ctx, b.clone());
         self.gate().assert_is_const(ctx, &b_is_zero, &F::zero());
 
-        self.neg_divide_unsafe(ctx, a, b)
+        self.neg_divide_unsafe(ctx, a.into(), b)
     }
 
     // Returns `-a / b` without constraining `b` to be nonzero.
@@ -217,43 +263,36 @@ pub trait FieldChip<F: PrimeField>: Clone + Debug + Send + Sync {
     fn neg_divide_unsafe(
         &self,
         ctx: &mut Context<F>,
-        a: &Self::FieldPoint,
-        b: &Self::FieldPoint,
+        a: impl Into<Self::UnsafeFieldPoint>,
+        b: impl Into<Self::UnsafeFieldPoint>,
     ) -> Self::FieldPoint {
-        let a_val = self.get_assigned_value(a);
-        let b_val = self.get_assigned_value(b);
+        let a = a.into();
+        let b = b.into();
+        let a_val = self.get_assigned_value(&a);
+        let b_val = self.get_assigned_value(&b);
         let b_inv: Self::FieldType = Option::from(b_val.invert()).unwrap_or_default();
         let quot_val = -a_val * b_inv;
 
-        let quot = self.load_private(ctx, Self::fe_to_witness(&quot_val));
-        self.range_check(ctx, &quot, Self::PRIME_FIELD_NUM_BITS as usize);
+        let quot = self.load_private(ctx, quot_val);
 
         // constrain quot * b + a = 0 mod p
-        let quot_b = self.mul_no_carry(ctx, &quot, b);
-        let quot_constraint = self.add_no_carry(ctx, &quot_b, a);
-        self.check_carry_mod_to_zero(ctx, &quot_constraint);
+        let quot_b = self.mul_no_carry(ctx, quot.clone(), b);
+        let quot_constraint = self.add_no_carry(ctx, quot_b, a);
+        self.check_carry_mod_to_zero(ctx, quot_constraint);
 
         quot
     }
 }
 
-pub trait Selectable<F: ScalarField> {
-    type Point;
-
-    fn select(
-        &self,
-        ctx: &mut Context<F>,
-        a: &Self::Point,
-        b: &Self::Point,
-        sel: AssignedValue<F>,
-    ) -> Self::Point;
+pub trait Selectable<F: ScalarField, Pt> {
+    fn select(&self, ctx: &mut Context<F>, a: Pt, b: Pt, sel: AssignedValue<F>) -> Pt;
 
     fn select_by_indicator(
         &self,
         ctx: &mut Context<F>,
-        a: &[Self::Point],
+        a: &impl AsRef<[Pt]>,
         coeffs: &[AssignedValue<F>],
-    ) -> Self::Point;
+    ) -> Pt;
 }
 
 // Common functionality for prime field chips

--- a/halo2-ecc/src/fields/tests/fp/assert_eq.rs
+++ b/halo2-ecc/src/fields/tests/fp/assert_eq.rs
@@ -8,13 +8,10 @@ use halo2_base::{
         RangeChip,
     },
     halo2_proofs::{
-        halo2curves::bn256::{Fq, Fr},
-        plonk::keygen_pk,
-        plonk::keygen_vk,
+        halo2curves::bn256::Fq, plonk::keygen_pk, plonk::keygen_vk,
         poly::kzg::commitment::ParamsKZG,
     },
 };
-use num_bigint::BigInt;
 
 use crate::{bn254::FpChip, fields::FieldChip};
 use rand::thread_rng;
@@ -30,8 +27,8 @@ fn test_fp_assert_eq_gen(k: u32, lookup_bits: usize, num_tries: usize) {
     let chip = FpChip::new(&range, 88, 3);
 
     let ctx = builder.main(0);
-    let a = chip.load_private(ctx, BigInt::from(0));
-    let b = chip.load_private(ctx, BigInt::from(0));
+    let a = chip.load_private(ctx, Fq::zero());
+    let b = chip.load_private(ctx, Fq::zero());
     chip.assert_equal(ctx, &a, &b);
     // set env vars
     builder.config(k as usize, Some(9));
@@ -51,7 +48,7 @@ fn test_fp_assert_eq_gen(k: u32, lookup_bits: usize, num_tries: usize) {
         let chip = FpChip::new(&range, 88, 3);
 
         let ctx = builder.main(0);
-        let [a, b] = [a, b].map(|x| chip.load_private(ctx, FpChip::<Fr>::fe_to_witness(&x)));
+        let [a, b] = [a, b].map(|x| chip.load_private(ctx, x));
         chip.assert_equal(ctx, &a, &b);
         let circuit = RangeCircuitBuilder::prover(builder, vec![vec![]]); // no break points
         gen_proof(&params, &pk, circuit)

--- a/halo2-ecc/src/fields/tests/fp/mod.rs
+++ b/halo2-ecc/src/fields/tests/fp/mod.rs
@@ -27,15 +27,12 @@ fn fp_mul_test<F: PrimeField>(
     let range = RangeChip::<F>::default(lookup_bits);
     let chip = FpChip::<F, Fq>::new(&range, limb_bits, num_limbs);
 
-    let [a, b] = [_a, _b].map(|x| chip.load_private(ctx, FpChip::<F, Fq>::fe_to_witness(&x)));
-    let c = chip.mul(ctx, &a, &b);
+    let [a, b] = [_a, _b].map(|x| chip.load_private(ctx, x));
+    let c = chip.mul(ctx, a, b);
 
-    assert_eq!(c.truncation.to_bigint(limb_bits), c.value);
-    assert_eq!(
-        c.native.value(),
-        &biguint_to_fe(&(&c.value.to_biguint().unwrap() % modulus::<F>()))
-    );
-    assert_eq!(c.value, fe_to_biguint(&(_a * _b)).into())
+    assert_eq!(c.0.truncation.to_bigint(limb_bits), c.0.value);
+    assert_eq!(c.native().value(), &biguint_to_fe(&(c.value() % modulus::<F>())));
+    assert_eq!(c.0.value, fe_to_biguint(&(_a * _b)).into())
 }
 
 #[test]

--- a/halo2-ecc/src/fields/tests/fp12/mod.rs
+++ b/halo2-ecc/src/fields/tests/fp12/mod.rs
@@ -25,13 +25,11 @@ fn fp12_mul_test<F: PrimeField>(
     let fp_chip = FpChip::<F, Fq>::new(&range, limb_bits, num_limbs);
     let chip = Fp12Chip::<F, _, Fq12, XI_0>::new(&fp_chip);
 
-    let [a, b] = [_a, _b].map(|x| {
-        chip.load_private(ctx, Fp12Chip::<F, FpChip<F, Fq>, Fq12, XI_0>::fe_to_witness(&x))
-    });
-    let c = chip.mul(ctx, &a, &b);
+    let [a, b] = [_a, _b].map(|x| chip.load_private(ctx, x));
+    let c = chip.mul(ctx, a, b).into();
 
     assert_eq!(chip.get_assigned_value(&c), _a * _b);
-    for c in c.coeffs {
+    for c in c.into_iter() {
         assert_eq!(c.truncation.to_bigint(limb_bits), c.value);
     }
 }

--- a/halo2-ecc/src/fields/vector.rs
+++ b/halo2-ecc/src/fields/vector.rs
@@ -1,0 +1,495 @@
+use halo2_base::{gates::GateInstructions, utils::ScalarField, AssignedValue, Context};
+use itertools::Itertools;
+use std::{
+    marker::PhantomData,
+    ops::{Index, IndexMut},
+};
+
+use crate::bigint::{CRTInteger, ProperCrtUint};
+
+use super::{fp::Reduced, FieldChip, FieldExtConstructor, PrimeField, PrimeFieldChip, Selectable};
+
+/// A fixed length vector of `FieldPoint`s
+#[repr(transparent)]
+#[derive(Clone, Debug)]
+pub struct FieldVector<T>(pub Vec<T>);
+
+impl<T> Index<usize> for FieldVector<T> {
+    type Output = T;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.0[index]
+    }
+}
+
+impl<T> IndexMut<usize> for FieldVector<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.0[index]
+    }
+}
+
+impl<T> AsRef<[T]> for FieldVector<T> {
+    fn as_ref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<'a, T: Clone, U: From<T>> From<&'a FieldVector<T>> for FieldVector<U> {
+    fn from(other: &'a FieldVector<T>) -> Self {
+        FieldVector(other.clone().into_iter().map(Into::into).collect())
+    }
+}
+
+impl<F: ScalarField> From<FieldVector<ProperCrtUint<F>>> for FieldVector<CRTInteger<F>> {
+    fn from(other: FieldVector<ProperCrtUint<F>>) -> Self {
+        FieldVector(other.into_iter().map(|x| x.0).collect())
+    }
+}
+
+impl<T, Fp> From<FieldVector<Reduced<T, Fp>>> for FieldVector<T> {
+    fn from(value: FieldVector<Reduced<T, Fp>>) -> Self {
+        FieldVector(value.0.into_iter().map(|x| x.0).collect())
+    }
+}
+
+impl<T> IntoIterator for FieldVector<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+/// Contains common functionality for vector operations that can be derived from those of the underlying `FpChip`
+#[derive(Clone, Copy, Debug)]
+pub struct FieldVectorChip<'fp, F: PrimeField, FpChip: FieldChip<F>> {
+    pub fp_chip: &'fp FpChip,
+    _f: PhantomData<F>,
+}
+
+impl<'fp, F, FpChip> FieldVectorChip<'fp, F, FpChip>
+where
+    F: PrimeField,
+    FpChip: PrimeFieldChip<F>,
+    FpChip::FieldType: PrimeField,
+{
+    pub fn new(fp_chip: &'fp FpChip) -> Self {
+        Self { fp_chip, _f: PhantomData }
+    }
+
+    pub fn gate(&self) -> &impl GateInstructions<F> {
+        self.fp_chip.gate()
+    }
+
+    pub fn fp_mul_no_carry<FP>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FP>,
+        fp_point: impl Into<FpChip::UnsafeFieldPoint>,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        FP: Into<FpChip::UnsafeFieldPoint>,
+    {
+        let fp_point = fp_point.into();
+        FieldVector(
+            a.into_iter().map(|a| self.fp_chip.mul_no_carry(ctx, a, fp_point.clone())).collect(),
+        )
+    }
+
+    pub fn select<FP>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FP>,
+        b: impl IntoIterator<Item = FP>,
+        sel: AssignedValue<F>,
+    ) -> FieldVector<FP>
+    where
+        FpChip: Selectable<F, FP>,
+    {
+        FieldVector(
+            a.into_iter().zip_eq(b).map(|(a, b)| self.fp_chip.select(ctx, a, b, sel)).collect(),
+        )
+    }
+
+    pub fn load_private<FieldExt, const DEGREE: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        fe: FieldExt,
+    ) -> FieldVector<FpChip::FieldPoint>
+    where
+        FieldExt: FieldExtConstructor<FpChip::FieldType, DEGREE>,
+    {
+        FieldVector(fe.coeffs().into_iter().map(|a| self.fp_chip.load_private(ctx, a)).collect())
+    }
+
+    pub fn load_constant<FieldExt, const DEGREE: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        c: FieldExt,
+    ) -> FieldVector<FpChip::FieldPoint>
+    where
+        FieldExt: FieldExtConstructor<FpChip::FieldType, DEGREE>,
+    {
+        FieldVector(c.coeffs().into_iter().map(|a| self.fp_chip.load_constant(ctx, a)).collect())
+    }
+
+    // signed overflow BigInt functions
+    pub fn add_no_carry<A, B>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        b: impl IntoIterator<Item = B>,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+        B: Into<FpChip::UnsafeFieldPoint>,
+    {
+        FieldVector(
+            a.into_iter().zip_eq(b).map(|(a, b)| self.fp_chip.add_no_carry(ctx, a, b)).collect(),
+        )
+    }
+
+    pub fn add_constant_no_carry<A, FieldExt, const DEGREE: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        c: FieldExt,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+        FieldExt: FieldExtConstructor<FpChip::FieldType, DEGREE>,
+    {
+        let c_coeffs = c.coeffs();
+        FieldVector(
+            a.into_iter()
+                .zip_eq(c_coeffs)
+                .map(|(a, c)| self.fp_chip.add_constant_no_carry(ctx, a, c))
+                .collect(),
+        )
+    }
+
+    pub fn sub_no_carry<A, B>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        b: impl IntoIterator<Item = B>,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+        B: Into<FpChip::UnsafeFieldPoint>,
+    {
+        FieldVector(
+            a.into_iter().zip_eq(b).map(|(a, b)| self.fp_chip.sub_no_carry(ctx, a, b)).collect(),
+        )
+    }
+
+    pub fn negate(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) -> FieldVector<FpChip::FieldPoint> {
+        FieldVector(a.into_iter().map(|a| self.fp_chip.negate(ctx, a)).collect())
+    }
+
+    pub fn scalar_mul_no_carry<A>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        c: i64,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+    {
+        FieldVector(a.into_iter().map(|a| self.fp_chip.scalar_mul_no_carry(ctx, a, c)).collect())
+    }
+
+    pub fn scalar_mul_and_add_no_carry<A, B>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        b: impl IntoIterator<Item = B>,
+        c: i64,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+        B: Into<FpChip::UnsafeFieldPoint>,
+    {
+        FieldVector(
+            a.into_iter()
+                .zip_eq(b)
+                .map(|(a, b)| self.fp_chip.scalar_mul_and_add_no_carry(ctx, a, b, c))
+                .collect(),
+        )
+    }
+
+    pub fn check_carry_mod_to_zero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::UnsafeFieldPoint>,
+    ) {
+        for coeff in a {
+            self.fp_chip.check_carry_mod_to_zero(ctx, coeff);
+        }
+    }
+
+    pub fn carry_mod(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::UnsafeFieldPoint>,
+    ) -> FieldVector<FpChip::FieldPoint> {
+        FieldVector(a.into_iter().map(|coeff| self.fp_chip.carry_mod(ctx, coeff)).collect())
+    }
+
+    pub fn range_check<A>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        max_bits: usize,
+    ) where
+        A: Into<FpChip::UnsafeFieldPoint>,
+    {
+        for coeff in a {
+            self.fp_chip.range_check(ctx, coeff, max_bits);
+        }
+    }
+
+    pub fn enforce_less_than(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) -> FieldVector<FpChip::ReducedFieldPoint> {
+        FieldVector(a.into_iter().map(|coeff| self.fp_chip.enforce_less_than(ctx, coeff)).collect())
+    }
+
+    pub fn is_soft_zero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) -> AssignedValue<F> {
+        let mut prev = None;
+        for a_coeff in a {
+            let coeff = self.fp_chip.is_soft_zero(ctx, a_coeff);
+            if let Some(p) = prev {
+                let new = self.gate().and(ctx, coeff, p);
+                prev = Some(new);
+            } else {
+                prev = Some(coeff);
+            }
+        }
+        prev.unwrap()
+    }
+
+    pub fn is_soft_nonzero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) -> AssignedValue<F> {
+        let mut prev = None;
+        for a_coeff in a {
+            let coeff = self.fp_chip.is_soft_nonzero(ctx, a_coeff);
+            if let Some(p) = prev {
+                let new = self.gate().or(ctx, coeff, p);
+                prev = Some(new);
+            } else {
+                prev = Some(coeff);
+            }
+        }
+        prev.unwrap()
+    }
+
+    pub fn is_zero(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) -> AssignedValue<F> {
+        let mut prev = None;
+        for a_coeff in a {
+            let coeff = self.fp_chip.is_zero(ctx, a_coeff);
+            if let Some(p) = prev {
+                let new = self.gate().and(ctx, coeff, p);
+                prev = Some(new);
+            } else {
+                prev = Some(coeff);
+            }
+        }
+        prev.unwrap()
+    }
+
+    pub fn is_equal_unenforced(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::ReducedFieldPoint>,
+        b: impl IntoIterator<Item = FpChip::ReducedFieldPoint>,
+    ) -> AssignedValue<F> {
+        let mut acc = None;
+        for (a_coeff, b_coeff) in a.into_iter().zip_eq(b) {
+            let coeff = self.fp_chip.is_equal_unenforced(ctx, a_coeff, b_coeff);
+            if let Some(c) = acc {
+                acc = Some(self.gate().and(ctx, coeff, c));
+            } else {
+                acc = Some(coeff);
+            }
+        }
+        acc.unwrap()
+    }
+
+    pub fn assert_equal(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = FpChip::FieldPoint>,
+        b: impl IntoIterator<Item = FpChip::FieldPoint>,
+    ) {
+        for (a_coeff, b_coeff) in a.into_iter().zip(b) {
+            self.fp_chip.assert_equal(ctx, a_coeff, b_coeff)
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! impl_field_ext_chip_common {
+    // Implementation of the functions in `FieldChip` trait for field extensions that can be derived from `FieldVectorChip`
+    () => {
+        fn native_modulus(&self) -> &BigUint {
+            self.0.fp_chip.native_modulus()
+        }
+
+        fn range(&self) -> &Self::RangeChip {
+            self.0.fp_chip.range()
+        }
+
+        fn limb_bits(&self) -> usize {
+            self.0.fp_chip.limb_bits()
+        }
+
+        fn load_private(&self, ctx: &mut Context<F>, fe: Self::FieldType) -> Self::FieldPoint {
+            self.0.load_private(ctx, fe)
+        }
+
+        fn load_constant(&self, ctx: &mut Context<F>, fe: Self::FieldType) -> Self::FieldPoint {
+            self.0.load_constant(ctx, fe)
+        }
+
+        fn add_no_carry(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            b: impl Into<Self::UnsafeFieldPoint>,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.add_no_carry(ctx, a.into(), b.into())
+        }
+
+        fn add_constant_no_carry(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            c: Self::FieldType,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.add_constant_no_carry(ctx, a.into(), c)
+        }
+
+        fn sub_no_carry(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            b: impl Into<Self::UnsafeFieldPoint>,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.sub_no_carry(ctx, a.into(), b.into())
+        }
+
+        fn negate(&self, ctx: &mut Context<F>, a: Self::FieldPoint) -> Self::FieldPoint {
+            self.0.negate(ctx, a)
+        }
+
+        fn scalar_mul_no_carry(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            c: i64,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.scalar_mul_no_carry(ctx, a.into(), c)
+        }
+
+        fn scalar_mul_and_add_no_carry(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            b: impl Into<Self::UnsafeFieldPoint>,
+            c: i64,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.scalar_mul_and_add_no_carry(ctx, a.into(), b.into(), c)
+        }
+
+        fn check_carry_mod_to_zero(&self, ctx: &mut Context<F>, a: Self::UnsafeFieldPoint) {
+            self.0.check_carry_mod_to_zero(ctx, a);
+        }
+
+        fn carry_mod(&self, ctx: &mut Context<F>, a: Self::UnsafeFieldPoint) -> Self::FieldPoint {
+            self.0.carry_mod(ctx, a)
+        }
+
+        fn range_check(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            max_bits: usize,
+        ) {
+            self.0.range_check(ctx, a.into(), max_bits)
+        }
+
+        fn enforce_less_than(
+            &self,
+            ctx: &mut Context<F>,
+            a: Self::FieldPoint,
+        ) -> Self::ReducedFieldPoint {
+            self.0.enforce_less_than(ctx, a)
+        }
+
+        fn is_soft_zero(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::FieldPoint>,
+        ) -> AssignedValue<F> {
+            let a = a.into();
+            self.0.is_soft_zero(ctx, a)
+        }
+
+        fn is_soft_nonzero(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::FieldPoint>,
+        ) -> AssignedValue<F> {
+            let a = a.into();
+            self.0.is_soft_nonzero(ctx, a)
+        }
+
+        fn is_zero(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::FieldPoint>,
+        ) -> AssignedValue<F> {
+            let a = a.into();
+            self.0.is_zero(ctx, a)
+        }
+
+        fn is_equal_unenforced(
+            &self,
+            ctx: &mut Context<F>,
+            a: Self::ReducedFieldPoint,
+            b: Self::ReducedFieldPoint,
+        ) -> AssignedValue<F> {
+            self.0.is_equal_unenforced(ctx, a, b)
+        }
+
+        fn assert_equal(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::FieldPoint>,
+            b: impl Into<Self::FieldPoint>,
+        ) {
+            let a = a.into();
+            let b = b.into();
+            self.0.assert_equal(ctx, a, b)
+        }
+    };
+}

--- a/halo2-ecc/src/secp256k1/tests/ecdsa.rs
+++ b/halo2-ecc/src/secp256k1/tests/ecdsa.rs
@@ -62,14 +62,13 @@ fn ecdsa_test<F: PrimeField>(
     let fp_chip = FpChip::<F>::new(&range, params.limb_bits, params.num_limbs);
     let fq_chip = FqChip::<F>::new(&range, params.limb_bits, params.num_limbs);
 
-    let [m, r, s] =
-        [msghash, r, s].map(|x| fq_chip.load_private(ctx, FqChip::<F>::fe_to_witness(&x)));
+    let [m, r, s] = [msghash, r, s].map(|x| fq_chip.load_private(ctx, x));
 
     let ecc_chip = EccChip::<F, FpChip<F>>::new(&fp_chip);
-    let pk = ecc_chip.load_private(ctx, (pk.x, pk.y));
+    let pk = ecc_chip.load_private_unchecked(ctx, (pk.x, pk.y));
     // test ECDSA
     let res = ecdsa_verify_no_pubkey_check::<F, Fp, Fq, Secp256k1Affine>(
-        &ecc_chip, ctx, &pk, &r, &s, &m, 4, 4,
+        &ecc_chip, ctx, pk, r, s, m, 4, 4,
     );
     assert_eq!(res.value(), &F::one());
 }


### PR DESCRIPTION
New types now guard for different assumptions on non-native bigint
arithmetic. We distinguish between:
- Overflow CRT integers
- Proper BigUint with native part derived from limbs
- Field elements where inequality < modulus is checked

Also add type to help guard for inequality check in
ec_add_unequal_strict

Rust traits did not play so nicely with references, so I had to switch
many functions to move inputs instead of borrow by reference. However to
avoid writing `clone` everywhere, we allow conversion `From` reference
to the new type via cloning.
