### PR TITLE
feat: use strict ec ops more often

### DIFF
--- a/halo2-ecc/src/ecc/ecdsa.rs
+++ b/halo2-ecc/src/ecc/ecdsa.rs
@@ -57,6 +57,7 @@ where
         u2.limbs().to_vec(),
         base_chip.limb_bits,
         var_window_bits,
+        true, // we can call it with scalar_is_safe = true because of the u2_small check below
     );
 
     // check u1 * G != -(u2 * pubkey) but allow u1 * G == u2 * pubkey
@@ -77,7 +78,6 @@ where
     let x1 = scalar_chip.enforce_less_than(ctx, sum.x);
     let equal_check = big_is_equal::assign(base_chip.gate(), ctx, x1.0, r);
 
-    // TODO: maybe the big_less_than is optional?
     let u1_small = big_less_than::assign(
         base_chip.range(),
         ctx,

--- a/halo2-ecc/src/ecc/pippenger.rs
+++ b/halo2-ecc/src/ecc/pippenger.rs
@@ -213,7 +213,6 @@ where
 /// * `scalars[i].len() == scalars[j].len()` for all `i, j`
 /// * `points` are all on the curve or the point at infinity
 /// * `points[i]` is allowed to be (0, 0) to represent the point at infinity (identity point)
-/// * `2^max_scalar_bits != +-1 mod modulus::<F>()` where `max_scalar_bits = max_scalar_bits_per_cell * scalars[0].len()`
 /// * Currently implementation assumes that the only point on curve with y-coordinate equal to `0` is identity point
 pub fn multi_exp_par<F: PrimeField, FC, C>(
     chip: &FC,
@@ -337,7 +336,7 @@ where
     // let any_point = (2^num_rounds - 1) * any_base
     // TODO: can we remove all these random point operations somehow?
     let mut any_point = ec_double(chip, ctx, any_points.last().unwrap());
-    any_point = ec_sub_unequal(chip, ctx, any_point, &any_points[0], false);
+    any_point = ec_sub_unequal(chip, ctx, any_point, &any_points[0], true);
 
     // compute sum_{k=0..scalar_bits} agg[k] * 2^k - (sum_{k=0..scalar_bits} 2^k) * rand_point
     // (sum_{k=0..scalar_bits} 2^k) = (2^scalar_bits - 1)
@@ -351,8 +350,7 @@ where
     }
 
     any_sum = ec_double(chip, ctx, any_sum);
-    // assume 2^scalar_bits != +-1 mod modulus::<F>()
-    any_sum = ec_sub_unequal(chip, ctx, any_sum, any_point, false);
+    any_sum = ec_sub_unequal(chip, ctx, any_sum, any_point, true);
 
     ec_sub_strict(chip, ctx, sum, any_sum)
 }


### PR DESCRIPTION
* `msm` implementations now always use `ec_{add,sub}_unequal` in strict mode for safety
* Add docs to `scalar_multiply` and a flag to specify when it's safe to turn off some strict assumptions