### PR TITLE
[feat] Add bitwise rotate operators for const bits

### DIFF
--- a/halo2-base/src/gates/flex_gate.rs
+++ b/halo2-base/src/gates/flex_gate.rs
@@ -916,7 +916,7 @@ impl<F: ScalarField> GateChip<F> {
         b_starts_with_one
     }
 
-    /// Bitwise right rotate a by <bit> bits. This function should never be called directly 
+    /// Bitwise right rotate a by <bit> bits. This function should never be called directly
     /// because const bitwise rotation must be determined at compile time.
     ///
     /// Assumes 'a' is a <num_bits> bit integer and <num_bits> <= 128.
@@ -926,27 +926,17 @@ impl<F: ScalarField> GateChip<F> {
         a: AssignedValue<F>,
         bit: usize,
         num_bits: usize,
-    ) -> AssignedValue<F>
-    {
+    ) -> AssignedValue<F> {
         // Add a constrain a = l_witness << bit | r_wintess
         let val = a.value().get_lower_128();
         let val_l = val >> bit;
         let val_r = val - (val_l << bit);
         let l_witness = Witness(F::from_u128(val_l));
         let r_witness = Witness(F::from_u128(val_r));
-        let val_witness = self.mul_add(
-            ctx, 
-            l_witness,
-            Constant(self.pow_of_two()[bit]),
-            r_witness,
-        );
+        let val_witness = self.mul_add(ctx, l_witness, Constant(self.pow_of_two()[bit]), r_witness);
         ctx.constrain_equal(&a, &val_witness);
-        // Return (r_witness << (num_bits - bit + 1)) | l_witness
-        self.mul_add(
-            ctx, 
-            r_witness,
-            Constant(self.pow_of_two()[num_bits - bit + 1]),
-            l_witness)
+        // Return (r_witness << (num_bits - bit)) | l_witness
+        self.mul_add(ctx, r_witness, Constant(self.pow_of_two()[num_bits - bit]), l_witness)
     }
 }
 
@@ -1198,7 +1188,7 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
         a: AssignedValue<F>,
     ) -> AssignedValue<F> {
         if BIT == 0 {
-            return a
+            return a;
         };
         self.const_right_rotate_unsafe_internal(ctx, a, BIT, NUM_BITS)
     }
@@ -1209,9 +1199,9 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
         a: AssignedValue<F>,
     ) -> AssignedValue<F> {
         if BIT == 0 {
-            return a
+            return a;
         };
         // left rotate by BIT == right rotate by (NUM_BITS - BIT)
-        self.const_right_rotate_unsafe_internal(ctx, a, NUM_BITS - BIT + 1, NUM_BITS)
+        self.const_right_rotate_unsafe_internal(ctx, a, NUM_BITS - BIT, NUM_BITS)
     }
 }

--- a/halo2-base/src/gates/flex_gate.rs
+++ b/halo2-base/src/gates/flex_gate.rs
@@ -812,6 +812,28 @@ pub trait GateInstructions<F: ScalarField> {
         let out = self.mul(ctx, eval.unwrap(), z);
         (out, z)
     }
+
+    /// Bitwise right rotate a by BIT bits. BIT and NUM_BITS must be determined at compile time.
+    ///
+    /// Assumes 'a' is a NUM_BITS bit integer and NUM_BITS <= 128.
+    /// * `ctx`: [Context] to add the constraints to
+    /// * `a`: a [AssignedValue] value.
+    fn const_right_rotate_unsafe<const BIT: usize, const NUM_BITS: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        a: AssignedValue<F>,
+    ) -> AssignedValue<F>;
+
+    /// Bitwise left rotate a by BIT bits. BIT and NUM_BITS must be determined at compile time.
+    ///
+    /// Assumes 'a' is a NUM_BITS bit integer and NUM_BITS <= 128.
+    /// * `ctx`: [Context] to add the constraints to
+    /// * `a`: a [AssignedValue] value.
+    fn const_left_rotate_unsafe<const BIT: usize, const NUM_BITS: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        a: AssignedValue<F>,
+    ) -> AssignedValue<F>;
 }
 
 /// A chip that implements the [GateInstructions] trait supporting basic arithmetic operations.
@@ -892,6 +914,39 @@ impl<F: ScalarField> GateChip<F> {
             ctx.assign_region(cells, (0..len).map(|i| 3 * i as isize));
         };
         b_starts_with_one
+    }
+
+    /// Bitwise right rotate a by <bit> bits. This function should never be called directly 
+    /// because const bitwise rotation must be determined at compile time.
+    ///
+    /// Assumes 'a' is a <num_bits> bit integer and <num_bits> <= 128.
+    fn const_right_rotate_unsafe_internal(
+        &self,
+        ctx: &mut Context<F>,
+        a: AssignedValue<F>,
+        bit: usize,
+        num_bits: usize,
+    ) -> AssignedValue<F>
+    {
+        // Add a constrain a = l_witness << bit | r_wintess
+        let val = a.value().get_lower_128();
+        let val_l = val >> bit;
+        let val_r = val - (val_l << bit);
+        let l_witness = Witness(F::from_u128(val_l));
+        let r_witness = Witness(F::from_u128(val_r));
+        let val_witness = self.mul_add(
+            ctx, 
+            l_witness,
+            Constant(self.pow_of_two()[bit]),
+            r_witness,
+        );
+        ctx.constrain_equal(&a, &val_witness);
+        // Return (r_witness << (num_bits - bit + 1)) | l_witness
+        self.mul_add(
+            ctx, 
+            r_witness,
+            Constant(self.pow_of_two()[num_bits - bit + 1]),
+            l_witness)
     }
 }
 
@@ -1135,5 +1190,28 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
             self.assert_bit(ctx, *bit_cell);
         }
         bit_cells
+    }
+
+    fn const_right_rotate_unsafe<const BIT: usize, const NUM_BITS: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        a: AssignedValue<F>,
+    ) -> AssignedValue<F> {
+        if BIT == 0 {
+            return a
+        };
+        self.const_right_rotate_unsafe_internal(ctx, a, BIT, NUM_BITS)
+    }
+
+    fn const_left_rotate_unsafe<const BIT: usize, const NUM_BITS: usize>(
+        &self,
+        ctx: &mut Context<F>,
+        a: AssignedValue<F>,
+    ) -> AssignedValue<F> {
+        if BIT == 0 {
+            return a
+        };
+        // left rotate by BIT == right rotate by (NUM_BITS - BIT)
+        self.const_right_rotate_unsafe_internal(ctx, a, NUM_BITS - BIT + 1, NUM_BITS)
     }
 }

--- a/halo2-base/src/gates/tests/bitwise_rotate.rs
+++ b/halo2-base/src/gates/tests/bitwise_rotate.rs
@@ -1,0 +1,90 @@
+use crate::{
+    gates::{
+        builder::{GateCircuitBuilder, GateThreadBuilder},
+        GateChip, GateInstructions,
+    },
+    halo2_proofs::{
+        plonk::keygen_pk,
+        plonk::{keygen_vk, Assigned},
+        poly::kzg::commitment::ParamsKZG,
+    },
+};
+
+use halo2_proofs_axiom::halo2curves::FieldExt;
+
+use super::*;
+
+// soundness checks for bitwise rotation functions
+fn test_bitwise_rotate_gen<const BIT: usize, const NUM_BITS: usize>(
+    k: u32, 
+    is_left: bool, 
+    a: u128, 
+    result_val: u128, 
+    expect_satisfied: bool
+) {
+    // first create proving and verifying key
+    let mut builder = GateThreadBuilder::keygen();
+    let gate = GateChip::default();
+    let dummy_a = builder.main(0).load_witness(Fr::zero());;
+    let result = if is_left {
+        gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(
+        builder.main(0), dummy_a)
+    } else {
+        gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(
+            builder.main(0), dummy_a)
+    };
+    // get the offsets of the indicator cells for later 'pranking'
+    let result_offsets = result.cell.unwrap().offset;
+    // set env vars
+    builder.config(k as usize, Some(9));
+    let circuit = GateCircuitBuilder::keygen(builder);
+
+    let params = ParamsKZG::setup(k, OsRng);
+    // generate proving key
+    let vk = keygen_vk(&params, &circuit).unwrap();
+    let pk = keygen_pk(&params, vk, &circuit).unwrap();
+    let vk = pk.get_vk(); // pk consumed vk
+
+    // now create different proofs to test the soundness of the circuit
+
+    let gen_pf = || {
+        let mut builder = GateThreadBuilder::prover();
+        let gate = GateChip::default();
+        let a_witness = builder.main(0).load_witness(Fr::from_u128(a));
+        if is_left {
+            gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(
+            builder.main(0), a_witness)
+        } else {
+            gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(
+                builder.main(0), a_witness)
+        };
+        builder.main(0).advice[result_offsets] = Assigned::Trivial(Fr::from_u128(result_val));
+        let circuit = GateCircuitBuilder::prover(builder, vec![vec![]]); // no break points
+        gen_proof(&params, &pk, circuit)
+    };
+
+    let pf = gen_pf();
+    check_proof(&params, vk, &pf, expect_satisfied);
+}
+
+#[test]
+fn test_bitwise_rotate() {
+    // 1 << 8 == 256
+    test_bitwise_rotate_gen::<8, 10>(8, true, 1, 256, true);
+    // 1 << 8 != 255
+    test_bitwise_rotate_gen::<8, 10>(8, true, 1, 255, false);
+    // 1 << 8 != 1
+    test_bitwise_rotate_gen::<8, 10>(8, true, 1, 1, false);
+    // 1 >> 1 == 1024
+    test_bitwise_rotate_gen::<1, 10>(8, false, 1, 1024, true);
+    // 1 >> 1 != 10
+    test_bitwise_rotate_gen::<1, 10>(8, false, 1, 10, false);
+    // 5 >> 2 == 513
+    test_bitwise_rotate_gen::<2, 10>(8, false, 5, 513, true);
+    // 5 >> 1 != 513
+    test_bitwise_rotate_gen::<1, 10>(8, false, 5, 513, false);
+    // 2047 << 5 != 2047
+    test_bitwise_rotate_gen::<5, 10>(8, true, 2047, 2047, true);
+    // 1 >> 5 != 2047
+    test_bitwise_rotate_gen::<5, 128>(8, false, 1, 1 << 124, true);
+}

--- a/halo2-base/src/gates/tests/bitwise_rotate.rs
+++ b/halo2-base/src/gates/tests/bitwise_rotate.rs
@@ -8,30 +8,30 @@ use crate::{
         plonk::{keygen_vk, Assigned},
         poly::kzg::commitment::ParamsKZG,
     },
+    utils::testing::{check_proof, gen_proof},
 };
 
 use halo2_proofs_axiom::halo2curves::FieldExt;
+use rand::rngs::OsRng;
 
 use super::*;
 
 // soundness checks for bitwise rotation functions
 fn test_bitwise_rotate_gen<const BIT: usize, const NUM_BITS: usize>(
-    k: u32, 
-    is_left: bool, 
-    a: u128, 
-    result_val: u128, 
-    expect_satisfied: bool
+    k: u32,
+    is_left: bool,
+    a: u128,
+    result_val: u128,
+    expect_satisfied: bool,
 ) {
     // first create proving and verifying key
     let mut builder = GateThreadBuilder::keygen();
     let gate = GateChip::default();
-    let dummy_a = builder.main(0).load_witness(Fr::zero());;
+    let dummy_a = builder.main(0).load_witness(Fr::zero());
     let result = if is_left {
-        gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(
-        builder.main(0), dummy_a)
+        gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(builder.main(0), dummy_a)
     } else {
-        gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(
-            builder.main(0), dummy_a)
+        gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(builder.main(0), dummy_a)
     };
     // get the offsets of the indicator cells for later 'pranking'
     let result_offsets = result.cell.unwrap().offset;
@@ -52,11 +52,9 @@ fn test_bitwise_rotate_gen<const BIT: usize, const NUM_BITS: usize>(
         let gate = GateChip::default();
         let a_witness = builder.main(0).load_witness(Fr::from_u128(a));
         if is_left {
-            gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(
-            builder.main(0), a_witness)
+            gate.const_left_rotate_unsafe::<BIT, NUM_BITS>(builder.main(0), a_witness)
         } else {
-            gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(
-                builder.main(0), a_witness)
+            gate.const_right_rotate_unsafe::<BIT, NUM_BITS>(builder.main(0), a_witness)
         };
         builder.main(0).advice[result_offsets] = Assigned::Trivial(Fr::from_u128(result_val));
         let circuit = GateCircuitBuilder::prover(builder, vec![vec![]]); // no break points
@@ -69,22 +67,25 @@ fn test_bitwise_rotate_gen<const BIT: usize, const NUM_BITS: usize>(
 
 #[test]
 fn test_bitwise_rotate() {
+    // "<<" is leftroate. ">>" is rightrotate.
     // 1 << 8 == 256
     test_bitwise_rotate_gen::<8, 10>(8, true, 1, 256, true);
     // 1 << 8 != 255
     test_bitwise_rotate_gen::<8, 10>(8, true, 1, 255, false);
     // 1 << 8 != 1
     test_bitwise_rotate_gen::<8, 10>(8, true, 1, 1, false);
-    // 1 >> 1 == 1024
-    test_bitwise_rotate_gen::<1, 10>(8, false, 1, 1024, true);
+    // 1 >> 1 == 512
+    test_bitwise_rotate_gen::<1, 10>(8, false, 1, 512, true);
     // 1 >> 1 != 10
     test_bitwise_rotate_gen::<1, 10>(8, false, 1, 10, false);
-    // 5 >> 2 == 513
-    test_bitwise_rotate_gen::<2, 10>(8, false, 5, 513, true);
+    // 5 >> 2 == 257
+    test_bitwise_rotate_gen::<2, 10>(8, false, 5, 257, true);
     // 5 >> 1 != 513
     test_bitwise_rotate_gen::<1, 10>(8, false, 5, 513, false);
-    // 2047 << 5 != 2047
-    test_bitwise_rotate_gen::<5, 10>(8, true, 2047, 2047, true);
-    // 1 >> 5 != 2047
-    test_bitwise_rotate_gen::<5, 128>(8, false, 1, 1 << 124, true);
+    // 1023u10 << 5 == 1023
+    test_bitwise_rotate_gen::<5, 10>(8, true, 1023, 1023, true);
+    // 1u128 >> 5 == 1u128 << 123
+    test_bitwise_rotate_gen::<5, 128>(8, false, 1, 1 << 123, true);
+    // 1u128 >> 5 != 2047
+    test_bitwise_rotate_gen::<5, 128>(8, false, 1, 2047, false);
 }

--- a/halo2-base/src/gates/tests/general.rs
+++ b/halo2-base/src/gates/tests/general.rs
@@ -3,10 +3,7 @@ use crate::gates::{
     flex_gate::{GateChip, GateInstructions},
     range::{RangeChip, RangeInstructions},
 };
-use crate::halo2_proofs::{
-    dev::MockProver,
-    halo2curves::bn256::Fr,
-};
+use crate::halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
 use crate::utils::{BigPrimeField, ScalarField};
 use crate::{Context, QuantumCell::Constant};
 use ff::Field;

--- a/halo2-base/src/gates/tests/idx_to_indicator.rs
+++ b/halo2-base/src/gates/tests/idx_to_indicator.rs
@@ -4,17 +4,17 @@ use crate::{
         GateChip, GateInstructions,
     },
     halo2_proofs::{
+        halo2curves::bn256::Fr,
         plonk::keygen_pk,
         plonk::{keygen_vk, Assigned},
         poly::kzg::commitment::ParamsKZG,
-        halo2curves::bn256::Fr,
     },
-    utils::testing::{gen_proof, check_proof},
+    utils::testing::{check_proof, gen_proof},
     QuantumCell::Witness,
 };
 use ff::Field;
 use itertools::Itertools;
-use rand::{thread_rng, Rng, rngs::OsRng};
+use rand::{rngs::OsRng, thread_rng, Rng};
 
 // soundness checks for `idx_to_indicator` function
 fn test_idx_to_indicator_gen(k: u32, len: usize) {

--- a/halo2-base/src/gates/tests/mod.rs
+++ b/halo2-base/src/gates/tests/mod.rs
@@ -1,5 +1,6 @@
 use crate::halo2_proofs::halo2curves::bn256::Fr;
 
+mod bitwise_rotate;
 mod flex_gate_tests;
 mod general;
 mod idx_to_indicator;

--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -41,10 +41,10 @@ use utils::ScalarField;
 
 /// Module that contains the main API for creating and working with circuits.
 pub mod gates;
-/// Utility functions for converting between different types of field elements.
-pub mod utils;
 /// Module for SafeType which enforce value range and realted functions.
 pub mod safe_types;
+/// Utility functions for converting between different types of field elements.
+pub mod utils;
 
 /// Constant representing whether the Layouter calls `synthesize` once just to get region shape.
 #[cfg(feature = "halo2-axiom")]


### PR DESCRIPTION
- Add `const_right_rotate_unsafe` and `const_left_rotate_unsafe` into `GateInstructions`. 
- These functions can bitwise left/rotate rotate a unsigned integer by a const bit.
- These functions don't do range checking so it's unsafe.