### PR TITLE
feat: revert to blanket implementation of `ScalarField`

### DIFF
--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -45,7 +45,7 @@ jemallocator = { version = "0.5", optional = true }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 
 [features]
-default = ["halo2-pse", "display"]
+default = ["halo2-axiom", "display"]
 dev-graph = ["halo2_proofs?/dev-graph", "halo2_proofs_axiom?/dev-graph", "plotters"]
 halo2-pse = ["halo2_proofs"]
 halo2-axiom = ["halo2_proofs_axiom"]

--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -45,7 +45,7 @@ jemallocator = { version = "0.5", optional = true }
 mimalloc = { version = "0.1", default-features = false, optional = true }
 
 [features]
-default = ["halo2-axiom", "display"]
+default = ["halo2-pse", "display"]
 dev-graph = ["halo2_proofs?/dev-graph", "halo2_proofs_axiom?/dev-graph", "plotters"]
 halo2-pse = ["halo2_proofs"]
 halo2-axiom = ["halo2_proofs_axiom"]


### PR DESCRIPTION
for easier integration with external crates, blanket implement `ScalarField` for `FieldExt + Hash` of fields that are ~256 bits

We do this in community-edition but not main branch because `ScalarField` assumes that `F::Repr` is in little endian. `ff::Field` leaves `Repr` endian-ness to be implementation specific, so this is not entirely safe