### PR TITLE
[Fix] Panic when dealing with identity point

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["main", "release-0.3.0"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release-0.3.0"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,12 @@ jobs:
           cd halo2-ecc
           cargo test -- --test-threads=1 test_fp
           cargo test -- test_ecc
-          cargo test -- test_secp256k1_ecdsa
+          cargo test -- test_secp
           cargo test -- test_ecdsa
           cargo test -- test_ec_add
-          cargo test -- test_fixed_base_msm
+          cargo test -- test_fixed
           cargo test -- test_msm
+          cargo test -- test_fb
           cargo test -- test_pairing
           cd ..
       - name: Run halo2-ecc tests real prover
@@ -40,7 +41,10 @@ jobs:
           cargo test --release -- test_fp_assert_eq
           cargo test --release -- --nocapture bench_secp256k1_ecdsa
           cargo test --release -- --nocapture bench_ec_add
+          mv configs/bn254/bench_fixed_msm.t.config configs/bn254/bench_fixed_msm.config
           cargo test --release -- --nocapture bench_fixed_base_msm
+          mv configs/bn254/bench_msm.t.config configs/bn254/bench_msm.config
           cargo test --release -- --nocapture bench_msm
+          mv configs/bn254/bench_pairing.t.config configs/bn254/bench_pairing.config
           cargo test --release -- --nocapture bench_pairing
           cd ..

--- a/halo2-ecc/configs/bn254/bench_fixed_msm.t.config
+++ b/halo2-ecc/configs/bn254/bench_fixed_msm.t.config
@@ -1,0 +1,5 @@
+{"strategy":"Simple","degree":17,"num_advice":83,"num_lookup_advice":9,"num_fixed":7,"lookup_bits":16,"limb_bits":88,"num_limbs":3,"batch_size":100,"radix":0,"clump_factor":4}
+{"strategy":"Simple","degree":18,"num_advice":42,"num_lookup_advice":5,"num_fixed":4,"lookup_bits":17,"limb_bits":88,"num_limbs":3,"batch_size":100,"radix":0,"clump_factor":4}
+{"strategy":"Simple","degree":19,"num_advice":20,"num_lookup_advice":2,"num_fixed":2,"lookup_bits":18,"limb_bits":90,"num_limbs":3,"batch_size":100,"radix":0,"clump_factor":4}
+{"strategy":"Simple","degree":19,"num_advice":6,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":18,"limb_bits":88,"num_limbs":3,"batch_size":25,"radix":0,"clump_factor":4}
+{"strategy":"Simple","degree":20,"num_advice":6,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":19,"limb_bits":88,"num_limbs":3,"batch_size":50,"radix":0,"clump_factor":4}

--- a/halo2-ecc/configs/bn254/bench_msm.t.config
+++ b/halo2-ecc/configs/bn254/bench_msm.t.config
@@ -1,0 +1,5 @@
+{"strategy":"Simple","degree":16,"num_advice":170,"num_lookup_advice":23,"num_fixed":1,"lookup_bits":15,"limb_bits":88,"num_limbs":3,"batch_size":100,"window_bits":4}
+{"strategy":"Simple","degree":17,"num_advice":84,"num_lookup_advice":11,"num_fixed":1,"lookup_bits":16,"limb_bits":88,"num_limbs":3,"batch_size":100,"window_bits":4}
+{"strategy":"Simple","degree":19,"num_advice":20,"num_lookup_advice":3,"num_fixed":1,"lookup_bits":18,"limb_bits":90,"num_limbs":3,"batch_size":100,"window_bits":4}
+{"strategy":"Simple","degree":19,"num_advice":6,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":18,"limb_bits":88,"num_limbs":3,"batch_size":25,"window_bits":4}
+{"strategy":"Simple","degree":20,"num_advice":6,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":19,"limb_bits":88,"num_limbs":3,"batch_size":50,"window_bits":4}

--- a/halo2-ecc/configs/bn254/bench_pairing.t.config
+++ b/halo2-ecc/configs/bn254/bench_pairing.t.config
@@ -1,0 +1,5 @@
+{"strategy":"Simple","degree":15,"num_advice":105,"num_lookup_advice":14,"num_fixed":1,"lookup_bits":14,"limb_bits":90,"num_limbs":3}
+{"strategy":"Simple","degree":17,"num_advice":25,"num_lookup_advice":3,"num_fixed":1,"lookup_bits":16,"limb_bits":88,"num_limbs":3}
+{"strategy":"Simple","degree":18,"num_advice":13,"num_lookup_advice":2,"num_fixed":1,"lookup_bits":17,"limb_bits":88,"num_limbs":3}
+{"strategy":"Simple","degree":19,"num_advice":6,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":18,"limb_bits":90,"num_limbs":3}
+{"strategy":"Simple","degree":20,"num_advice":3,"num_lookup_advice":1,"num_fixed":1,"lookup_bits":19,"limb_bits":88,"num_limbs":3}

--- a/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
+++ b/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use rand_core::OsRng;
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-struct MSMCircuitParams {
+struct FixedMSMCircuitParams {
     strategy: FpStrategy,
     degree: u32,
     num_advice: usize,
@@ -39,7 +39,7 @@ struct MSMCircuitParams {
 
 fn fixed_base_msm_test(
     builder: &mut GateThreadBuilder<Fr>,
-    params: MSMCircuitParams,
+    params: FixedMSMCircuitParams,
     bases: Vec<G1Affine>,
     scalars: Vec<Fr>,
 ) {
@@ -68,7 +68,7 @@ fn fixed_base_msm_test(
 }
 
 fn random_fixed_base_msm_circuit(
-    params: MSMCircuitParams,
+    params: FixedMSMCircuitParams,
     bases: Vec<G1Affine>, // bases are fixed in vkey so don't randomly generate
     stage: CircuitBuilderStage,
     break_points: Option<MultiPhaseThreadBreakPoints>,
@@ -102,13 +102,30 @@ fn random_fixed_base_msm_circuit(
 #[test]
 fn test_fixed_base_msm() {
     let path = "configs/bn254/fixed_msm_circuit.config";
-    let params: MSMCircuitParams = serde_json::from_reader(
+    let params: FixedMSMCircuitParams = serde_json::from_reader(
         File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
     )
     .unwrap();
 
     let bases = (0..params.batch_size).map(|_| G1Affine::random(OsRng)).collect_vec();
     let circuit = random_fixed_base_msm_circuit(params, bases, CircuitBuilderStage::Mock, None);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_fixed_msm_minus_1() {
+    let path = "configs/bn254/fixed_msm_circuit.config";
+    let params: FixedMSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    let base = G1Affine::random(OsRng);
+    let k = params.degree as usize;
+    let mut builder = GateThreadBuilder::mock();
+    fixed_base_msm_test(&mut builder, params, vec![base], vec![-Fr::one()]);
+
+    builder.config(k, Some(20));
+    let circuit = RangeCircuitBuilder::mock(builder);
     MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
 }
 
@@ -126,7 +143,8 @@ fn bench_fixed_base_msm() -> Result<(), Box<dyn std::error::Error>> {
 
     let bench_params_reader = BufReader::new(bench_params_file);
     for line in bench_params_reader.lines() {
-        let bench_params: MSMCircuitParams = serde_json::from_str(line.unwrap().as_str()).unwrap();
+        let bench_params: FixedMSMCircuitParams =
+            serde_json::from_str(line.unwrap().as_str()).unwrap();
         let k = bench_params.degree;
         println!("---------------------- degree = {k} ------------------------------",);
         let rng = OsRng;

--- a/halo2-ecc/src/bn254/tests/mod.rs
+++ b/halo2-ecc/src/bn254/tests/mod.rs
@@ -25,3 +25,4 @@ pub mod ec_add;
 pub mod fixed_base_msm;
 pub mod msm;
 pub mod pairing;
+pub mod msm_sum_infinity;

--- a/halo2-ecc/src/bn254/tests/mod.rs
+++ b/halo2-ecc/src/bn254/tests/mod.rs
@@ -1,20 +1,23 @@
 #![allow(non_snake_case)]
 use super::pairing::PairingChip;
 use super::*;
-use crate::halo2_proofs::{
-    dev::MockProver,
-    halo2curves::bn256::{pairing, Bn256, Fr, G1Affine},
-    plonk::*,
-    poly::commitment::ParamsProver,
-    poly::kzg::{
-        commitment::KZGCommitmentScheme,
-        multiopen::{ProverSHPLONK, VerifierSHPLONK},
-        strategy::SingleStrategy,
-    },
-    transcript::{Blake2bRead, Blake2bWrite, Challenge255},
-    transcript::{TranscriptReadBuffer, TranscriptWriterBuffer},
-};
 use crate::{ecc::EccChip, fields::PrimeField};
+use crate::{
+    fields::FpStrategy,
+    halo2_proofs::{
+        dev::MockProver,
+        halo2curves::bn256::{pairing, Bn256, Fr, G1Affine},
+        plonk::*,
+        poly::commitment::ParamsProver,
+        poly::kzg::{
+            commitment::KZGCommitmentScheme,
+            multiopen::{ProverSHPLONK, VerifierSHPLONK},
+            strategy::SingleStrategy,
+        },
+        transcript::{Blake2bRead, Blake2bWrite, Challenge255},
+        transcript::{TranscriptReadBuffer, TranscriptWriterBuffer},
+    },
+};
 use ark_std::{end_timer, start_timer};
 use group::Curve;
 use halo2_base::utils::fe_to_biguint;
@@ -24,5 +27,20 @@ use std::io::Write;
 pub mod ec_add;
 pub mod fixed_base_msm;
 pub mod msm;
-pub mod pairing;
 pub mod msm_sum_infinity;
+pub mod msm_sum_infinity_fixed_base;
+pub mod pairing;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct MSMCircuitParams {
+    strategy: FpStrategy,
+    degree: u32,
+    num_advice: usize,
+    num_lookup_advice: usize,
+    num_fixed: usize,
+    lookup_bits: usize,
+    limb_bits: usize,
+    num_limbs: usize,
+    batch_size: usize,
+    window_bits: usize,
+}

--- a/halo2-ecc/src/bn254/tests/msm_sum_infinity.rs
+++ b/halo2-ecc/src/bn254/tests/msm_sum_infinity.rs
@@ -1,0 +1,198 @@
+use crate::fields::FpStrategy;
+use ff::PrimeField;
+use halo2_base::gates::{
+    builder::{
+        CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints, RangeCircuitBuilder,
+    },
+    RangeChip,
+};
+use rand_core::OsRng;
+use std::fs::File;
+
+use super::*;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct MSMCircuitParams {
+    strategy: FpStrategy,
+    degree: u32,
+    num_advice: usize,
+    num_lookup_advice: usize,
+    num_fixed: usize,
+    lookup_bits: usize,
+    limb_bits: usize,
+    num_limbs: usize,
+    batch_size: usize,
+    window_bits: usize,
+}
+
+fn msm_test(
+    builder: &mut GateThreadBuilder<Fr>,
+    params: MSMCircuitParams,
+    bases: Vec<G1Affine>,
+    scalars: Vec<Fr>,
+    window_bits: usize,
+) {
+    std::env::set_var("LOOKUP_BITS", params.lookup_bits.to_string());
+    let range = RangeChip::<Fr>::default(params.lookup_bits);
+    let fp_chip = FpChip::<Fr>::new(&range, params.limb_bits, params.num_limbs);
+    let ecc_chip = EccChip::new(&fp_chip);
+
+    let ctx = builder.main(0);
+    let scalars_assigned =
+        scalars.iter().map(|scalar| vec![ctx.load_witness(*scalar)]).collect::<Vec<_>>();
+    let bases_assigned = bases
+        .iter()
+        .map(|base| ecc_chip.load_private_unchecked(ctx, (base.x, base.y)))
+        .collect::<Vec<_>>();
+
+    let msm = ecc_chip.variable_base_msm_in::<G1Affine>(
+        builder,
+        &bases_assigned,
+        scalars_assigned,
+        Fr::NUM_BITS as usize,
+        window_bits,
+        0,
+    );
+
+    let msm_answer = bases
+        .iter()
+        .zip(scalars.iter())
+        .map(|(base, scalar)| base * scalar)
+        .reduce(|a, b| a + b)
+        .unwrap()
+        .to_affine();
+
+    let msm_x = msm.x.value();
+    let msm_y = msm.y.value();
+    assert_eq!(msm_x, fe_to_biguint(&msm_answer.x));
+    assert_eq!(msm_y, fe_to_biguint(&msm_answer.y));
+}
+
+fn custom_msm_circuit(
+    params: MSMCircuitParams,
+    stage: CircuitBuilderStage,
+    break_points: Option<MultiPhaseThreadBreakPoints>,
+    bases: Vec<G1Affine>,
+    scalars: Vec<Fr>,
+) -> RangeCircuitBuilder<Fr> {
+    let k = params.degree as usize;
+    let mut builder = match stage {
+        CircuitBuilderStage::Mock => GateThreadBuilder::mock(),
+        CircuitBuilderStage::Prover => GateThreadBuilder::prover(),
+        CircuitBuilderStage::Keygen => GateThreadBuilder::keygen(),
+    };
+
+    let start0 = start_timer!(|| format!("Witness generation for circuit in {stage:?} stage"));
+    msm_test(&mut builder, params, bases, scalars, params.window_bits);
+
+    let circuit = match stage {
+        CircuitBuilderStage::Mock => {
+            builder.config(k, Some(20));
+            RangeCircuitBuilder::mock(builder)
+        }
+        CircuitBuilderStage::Keygen => {
+            builder.config(k, Some(20));
+            RangeCircuitBuilder::keygen(builder)
+        }
+        CircuitBuilderStage::Prover => RangeCircuitBuilder::prover(builder, break_points.unwrap()),
+    };
+    end_timer!(start0);
+    circuit
+}
+
+#[test]
+fn test_msm1() {
+    let path = "configs/bn254/msm_circuit.config";
+    let mut params: MSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    params.batch_size = 3;
+
+    let random_point = G1Affine::random(OsRng);
+    let bases = vec![random_point, random_point, random_point];
+    let scalars = vec![Fr::one(), Fr::one(), -Fr::one() - Fr::one()];
+
+    let circuit = custom_msm_circuit(params, CircuitBuilderStage::Mock, None, bases, scalars);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_msm2() {
+    let path = "configs/bn254/msm_circuit.config";
+    let mut params: MSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    params.batch_size = 3;
+
+    let random_point = G1Affine::random(OsRng);
+    let bases = vec![random_point, random_point, (random_point + random_point).to_affine()];
+    let scalars = vec![Fr::one(), Fr::one(), -Fr::one()];
+
+    let circuit = custom_msm_circuit(params, CircuitBuilderStage::Mock, None, bases, scalars);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_msm3() {
+    let path = "configs/bn254/msm_circuit.config";
+    let mut params: MSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    params.batch_size = 4;
+
+    let random_point = G1Affine::random(OsRng);
+    let bases = vec![
+        random_point,
+        random_point,
+        random_point,
+        (random_point + random_point + random_point).to_affine(),
+    ];
+    let scalars = vec![Fr::one(), Fr::one(), Fr::one(), -Fr::one()];
+
+    let circuit = custom_msm_circuit(params, CircuitBuilderStage::Mock, None, bases, scalars);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_msm4() {
+    let path = "configs/bn254/msm_circuit.config";
+    let mut params: MSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    params.batch_size = 4;
+
+    let generator_point = G1Affine::generator();
+    let bases = vec![
+        generator_point,
+        generator_point,
+        generator_point,
+        (generator_point + generator_point + generator_point).to_affine(),
+    ];
+    let scalars = vec![Fr::one(), Fr::one(), Fr::one(), -Fr::one()];
+
+    let circuit = custom_msm_circuit(params, CircuitBuilderStage::Mock, None, bases, scalars);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_msm5() {
+    // Very similar example that does not add to infinity. It works fine.
+    let path = "configs/bn254/msm_circuit.config";
+    let mut params: MSMCircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+    params.batch_size = 4;
+
+    let random_point = G1Affine::random(OsRng);
+    let bases =
+        vec![random_point, random_point, random_point, (random_point + random_point).to_affine()];
+    let scalars = vec![-Fr::one(), -Fr::one(), Fr::one(), Fr::one()];
+
+    let circuit = custom_msm_circuit(params, CircuitBuilderStage::Mock, None, bases, scalars);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}

--- a/halo2-ecc/src/bn254/tests/msm_sum_infinity_fixed_base.rs
+++ b/halo2-ecc/src/bn254/tests/msm_sum_infinity_fixed_base.rs
@@ -25,12 +25,12 @@ fn msm_test(
     let ctx = builder.main(0);
     let scalars_assigned =
         scalars.iter().map(|scalar| vec![ctx.load_witness(*scalar)]).collect::<Vec<_>>();
-    let bases_assigned = bases
-        .iter()
-        .map(|base| ecc_chip.load_private_unchecked(ctx, (base.x, base.y)))
-        .collect::<Vec<_>>();
+    let bases_assigned = bases;
+    //.iter()
+    //.map(|base| ecc_chip.load_private_unchecked(ctx, (base.x, base.y)))
+    //.collect::<Vec<_>>();
 
-    let msm = ecc_chip.variable_base_msm_in::<G1Affine>(
+    let msm = ecc_chip.fixed_base_msm_in::<G1Affine>(
         builder,
         &bases_assigned,
         scalars_assigned,
@@ -39,7 +39,7 @@ fn msm_test(
         0,
     );
 
-    let msm_answer = bases
+    let msm_answer = bases_assigned
         .iter()
         .zip(scalars.iter())
         .map(|(base, scalar)| base * scalar)
@@ -86,7 +86,7 @@ fn custom_msm_circuit(
 }
 
 #[test]
-fn test_msm1() {
+fn test_fb_msm1() {
     let path = "configs/bn254/msm_circuit.config";
     let mut params: MSMCircuitParams = serde_json::from_reader(
         File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
@@ -103,7 +103,7 @@ fn test_msm1() {
 }
 
 #[test]
-fn test_msm2() {
+fn test_fb_msm2() {
     let path = "configs/bn254/msm_circuit.config";
     let mut params: MSMCircuitParams = serde_json::from_reader(
         File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
@@ -120,7 +120,7 @@ fn test_msm2() {
 }
 
 #[test]
-fn test_msm3() {
+fn test_fb_msm3() {
     let path = "configs/bn254/msm_circuit.config";
     let mut params: MSMCircuitParams = serde_json::from_reader(
         File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
@@ -142,7 +142,7 @@ fn test_msm3() {
 }
 
 #[test]
-fn test_msm4() {
+fn test_fb_msm4() {
     let path = "configs/bn254/msm_circuit.config";
     let mut params: MSMCircuitParams = serde_json::from_reader(
         File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
@@ -164,7 +164,7 @@ fn test_msm4() {
 }
 
 #[test]
-fn test_msm5() {
+fn test_fb_msm5() {
     // Very similar example that does not add to infinity. It works fine.
     let path = "configs/bn254/msm_circuit.config";
     let mut params: MSMCircuitParams = serde_json::from_reader(

--- a/halo2-ecc/src/ecc/ecdsa.rs
+++ b/halo2-ecc/src/ecc/ecdsa.rs
@@ -3,8 +3,7 @@ use halo2_base::{gates::GateInstructions, utils::CurveAffineExt, AssignedValue, 
 use crate::bigint::{big_is_equal, big_less_than, FixedOverflowInteger, ProperCrtUint};
 use crate::fields::{fp::FpChip, FieldChip, PrimeField};
 
-use super::{fixed_base, EccChip};
-use super::{scalar_multiply, EcPoint};
+use super::{fixed_base, scalar_multiply, EcPoint, EccChip};
 // CF is the coordinate field of GA
 // SF is the scalar field of GA
 // p = coordinate field modulus
@@ -12,6 +11,7 @@ use super::{scalar_multiply, EcPoint};
 // Only valid when p is very close to n in size (e.g. for Secp256k1)
 // Assumes `r, s` are proper CRT integers
 /// **WARNING**: Only use this function if `1 / (p - n)` is very small (e.g., < 2<sup>-100</sup>)
+/// `pubkey` should not be the identity point
 pub fn ecdsa_verify_no_pubkey_check<F: PrimeField, CF: PrimeField, SF: PrimeField, GA>(
     chip: &EccChip<F, FpChip<F, CF>>,
     ctx: &mut Context<F>,
@@ -49,16 +49,14 @@ where
         u1.limbs().to_vec(),
         base_chip.limb_bits,
         fixed_window_bits,
-        true, // we can call it with scalar_is_safe = true because of the u1_small check below
     );
-    let u2_mul = scalar_multiply(
+    let u2_mul = scalar_multiply::<_, _, GA>(
         base_chip,
         ctx,
         pubkey,
         u2.limbs().to_vec(),
         base_chip.limb_bits,
         var_window_bits,
-        true, // we can call it with scalar_is_safe = true because of the u2_small check below
     );
 
     // check u1 * G != -(u2 * pubkey) but allow u1 * G == u2 * pubkey

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -3,9 +3,10 @@ use crate::fields::{fp::FpChip, FieldChip, PrimeField, Selectable};
 use crate::halo2_proofs::arithmetic::CurveAffine;
 use group::{Curve, Group};
 use halo2_base::gates::builder::GateThreadBuilder;
+use halo2_base::utils::modulus;
 use halo2_base::{
     gates::{GateInstructions, RangeInstructions},
-    utils::{modulus, CurveAffineExt},
+    utils::CurveAffineExt,
     AssignedValue, Context,
 };
 use itertools::Itertools;
@@ -480,26 +481,26 @@ where
 /// - an array of length > 1 is needed when `scalar` exceeds the modulus of scalar field `F`
 ///
 /// # Assumptions
-/// - `P` is not the point at infinity
-/// - `scalar > 0`
-/// - If `scalar_is_safe == true`, then we assume the integer `scalar` is in range [1, order of `P`)
-/// - Even if `scalar_is_safe == false`, some constraints may still fail if `scalar` is not in range [1, order of `P`)
+/// - `window_bits != 0`
+/// - The order of `P` is at least `2^{window_bits}` (in particular, `P` is not the point at infinity)
+/// - The curve has no points of order 2.
 /// - `scalar_i < 2^{max_bits} for all i`
 /// - `max_bits <= modulus::<F>.bits()`, and equality only allowed when the order of `P` equals the modulus of `F`
-pub fn scalar_multiply<F: PrimeField, FC>(
+pub fn scalar_multiply<F: PrimeField, FC, C>(
     chip: &FC,
     ctx: &mut Context<F>,
     P: EcPoint<F, FC::FieldPoint>,
     scalar: Vec<AssignedValue<F>>,
     max_bits: usize,
     window_bits: usize,
-    scalar_is_safe: bool,
 ) -> EcPoint<F, FC::FieldPoint>
 where
     FC: FieldChip<F> + Selectable<F, FC::FieldPoint>,
+    C: CurveAffineExt<Base = FC::FieldType>,
 {
     assert!(!scalar.is_empty());
     assert!((max_bits as u64) <= modulus::<F>().bits());
+    assert!(window_bits != 0);
 
     let total_bits = max_bits * scalar.len();
     let num_windows = (total_bits + window_bits - 1) / window_bits;
@@ -517,7 +518,7 @@ where
     // is_started[idx] holds whether there is a 1 in bits with index at least (rounded_bitlen - idx)
     let mut is_started = Vec::with_capacity(rounded_bitlen);
     is_started.resize(rounded_bitlen - total_bits + 1, zero_cell);
-    for idx in 1..total_bits {
+    for idx in 1..=total_bits {
         let or = chip.gate().or(ctx, *is_started.last().unwrap(), rounded_bits[total_bits - idx]);
         is_started.push(or);
     }
@@ -534,22 +535,23 @@ where
         is_zero_window.push(is_zero);
     }
 
-    // cached_points[idx] stores idx * P, with cached_points[0] = P
+    let any_point = load_random_point::<F, FC, C>(chip, ctx);
+    // cached_points[idx] stores idx * P, with cached_points[0] = any_point
     let cache_size = 1usize << window_bits;
     let mut cached_points = Vec::with_capacity(cache_size);
-    cached_points.push(P.clone());
+    cached_points.push(any_point);
     cached_points.push(P.clone());
     for idx in 2..cache_size {
         if idx == 2 {
             let double = ec_double(chip, ctx, &P);
             cached_points.push(double);
         } else {
-            let new_point = ec_add_unequal(chip, ctx, &cached_points[idx - 1], &P, !scalar_is_safe);
+            let new_point = ec_add_unequal(chip, ctx, &cached_points[idx - 1], &P, false);
             cached_points.push(new_point);
         }
     }
 
-    // if all the starting window bits are 0, get start_point = P
+    // if all the starting window bits are 0, get start_point = any_point
     let mut curr_point = ec_select_from_bits(
         chip,
         ctx,
@@ -569,13 +571,17 @@ where
             &rounded_bits
                 [rounded_bitlen - window_bits * (idx + 1)..rounded_bitlen - window_bits * idx],
         );
-        let mult_and_add = ec_add_unequal(chip, ctx, &mult_point, &add_point, !scalar_is_safe);
+        // if is_zero_window[idx] = true, add_point = any_point. We only need any_point to avoid divide by zero in add_unequal
+        // if is_zero_window = true and is_started = false, then mult_point = 2^window_bits * any_point. Since window_bits != 0, we have mult_point != +- any_point
+        let mult_and_add = ec_add_unequal(chip, ctx, &mult_point, &add_point, true);
         let is_started_point = ec_select(chip, ctx, mult_point, mult_and_add, is_zero_window[idx]);
 
         curr_point =
             ec_select(chip, ctx, is_started_point, add_point, is_started[window_bits * idx]);
     }
-    curr_point
+    // if at the end, return identity point (0,0) if still not started
+    let zero = chip.load_constant(ctx, FC::FieldType::zero());
+    ec_select(chip, ctx, curr_point, EcPoint::new(zero.clone(), zero), *is_started.last().unwrap())
 }
 
 /// Checks that `P` is indeed a point on the elliptic curve `C`.
@@ -1018,24 +1024,18 @@ where
     }
 
     /// See [`scalar_multiply`] for more details.
-    pub fn scalar_mult(
+    pub fn scalar_mult<C>(
         &self,
         ctx: &mut Context<F>,
         P: EcPoint<F, FC::FieldPoint>,
         scalar: Vec<AssignedValue<F>>,
         max_bits: usize,
         window_bits: usize,
-        scalar_is_safe: bool,
-    ) -> EcPoint<F, FC::FieldPoint> {
-        scalar_multiply::<F, FC>(
-            self.field_chip,
-            ctx,
-            P,
-            scalar,
-            max_bits,
-            window_bits,
-            scalar_is_safe,
-        )
+    ) -> EcPoint<F, FC::FieldPoint>
+    where
+        C: CurveAffineExt<Base = FC::FieldType>,
+    {
+        scalar_multiply::<F, FC, C>(self.field_chip, ctx, P, scalar, max_bits, window_bits)
     }
 
     // default for most purposes
@@ -1049,14 +1049,13 @@ where
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt<Base = FC::FieldType>,
-        C::Base: ff::PrimeField,
         FC: Selectable<F, FC::ReducedFieldPoint>,
     {
         // window_bits = 4 is optimal from empirical observations
         self.variable_base_msm_in::<C>(thread_pool, P, scalars, max_bits, 4, 0)
     }
 
-    // TODO: put a check in place that scalar is < modulus of C::Scalar
+    // TODO: add asserts to validate input assumptions described in docs
     pub fn variable_base_msm_in<C>(
         &self,
         builder: &mut GateThreadBuilder<F>,
@@ -1068,7 +1067,6 @@ where
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt<Base = FC::FieldType>,
-        C::Base: ff::PrimeField,
         FC: Selectable<F, FC::ReducedFieldPoint>,
     {
         #[cfg(feature = "display")]
@@ -1115,7 +1113,6 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
         scalar: Vec<AssignedValue<F>>,
         max_bits: usize,
         window_bits: usize,
-        scalar_is_safe: bool,
     ) -> EcPoint<F, FC::FieldPoint>
     where
         C: CurveAffineExt,
@@ -1128,7 +1125,6 @@ impl<'chip, F: PrimeField, FC: FieldChip<F>> EccChip<'chip, F, FC> {
             scalar,
             max_bits,
             window_bits,
-            scalar_is_safe,
         )
     }
 

--- a/halo2-ecc/src/secp256k1/tests/ecdsa_tests.rs
+++ b/halo2-ecc/src/secp256k1/tests/ecdsa_tests.rs
@@ -1,5 +1,4 @@
 #![allow(non_snake_case)]
-use crate::fields::FpStrategy;
 use crate::halo2_proofs::{
     arithmetic::CurveAffine,
     dev::MockProver,
@@ -21,21 +20,10 @@ use halo2_base::utils::{biguint_to_fe, fe_to_biguint, modulus};
 use halo2_base::Context;
 use rand::random;
 use rand_core::OsRng;
-use serde::{Deserialize, Serialize};
 use std::fs::File;
 use test_case::test_case;
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
-struct CircuitParams {
-    strategy: FpStrategy,
-    degree: u32,
-    num_advice: usize,
-    num_lookup_advice: usize,
-    num_fixed: usize,
-    lookup_bits: usize,
-    limb_bits: usize,
-    num_limbs: usize,
-}
+use super::CircuitParams;
 
 fn ecdsa_test<F: PrimeField>(
     ctx: &mut Context<F>,

--- a/halo2-ecc/src/secp256k1/tests/mod.rs
+++ b/halo2-ecc/src/secp256k1/tests/mod.rs
@@ -1,2 +1,162 @@
+#![allow(non_snake_case)]
+use std::fs::File;
+
+use ff::Field;
+use group::Curve;
+use halo2_base::{
+    gates::{
+        builder::{
+            CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints,
+            RangeCircuitBuilder,
+        },
+        RangeChip,
+    },
+    halo2_proofs::{
+        dev::MockProver,
+        halo2curves::{
+            bn256::Fr,
+            secp256k1::{Fq, Secp256k1Affine},
+        },
+    },
+    utils::{biguint_to_fe, fe_to_biguint, BigPrimeField},
+    Context,
+};
+use num_bigint::BigUint;
+use rand_core::OsRng;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ecc::EccChip,
+    fields::{FieldChip, FpStrategy},
+    secp256k1::{FpChip, FqChip},
+};
+
 pub mod ecdsa;
 pub mod ecdsa_tests;
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+struct CircuitParams {
+    strategy: FpStrategy,
+    degree: u32,
+    num_advice: usize,
+    num_lookup_advice: usize,
+    num_fixed: usize,
+    lookup_bits: usize,
+    limb_bits: usize,
+    num_limbs: usize,
+}
+
+fn sm_test<F: BigPrimeField>(
+    ctx: &mut Context<F>,
+    params: CircuitParams,
+    base: Secp256k1Affine,
+    scalar: Fq,
+    window_bits: usize,
+) {
+    std::env::set_var("LOOKUP_BITS", params.lookup_bits.to_string());
+    let range = RangeChip::<F>::default(params.lookup_bits);
+    let fp_chip = FpChip::<F>::new(&range, params.limb_bits, params.num_limbs);
+    let fq_chip = FqChip::<F>::new(&range, params.limb_bits, params.num_limbs);
+    let ecc_chip = EccChip::<F, FpChip<F>>::new(&fp_chip);
+
+    let s = fq_chip.load_private(ctx, scalar);
+    let P = ecc_chip.assign_point(ctx, base);
+
+    let sm = ecc_chip.scalar_mult::<Secp256k1Affine>(
+        ctx,
+        P,
+        s.limbs().to_vec(),
+        fq_chip.limb_bits,
+        window_bits,
+    );
+
+    let sm_answer = (base * scalar).to_affine();
+
+    let sm_x = sm.x.value();
+    let sm_y = sm.y.value();
+    assert_eq!(sm_x, fe_to_biguint(&sm_answer.x));
+    assert_eq!(sm_y, fe_to_biguint(&sm_answer.y));
+}
+
+fn sm_circuit(
+    params: CircuitParams,
+    stage: CircuitBuilderStage,
+    break_points: Option<MultiPhaseThreadBreakPoints>,
+    base: Secp256k1Affine,
+    scalar: Fq,
+) -> RangeCircuitBuilder<Fr> {
+    let k = params.degree as usize;
+    let mut builder = GateThreadBuilder::new(stage == CircuitBuilderStage::Prover);
+
+    sm_test(builder.main(0), params, base, scalar, 4);
+
+    match stage {
+        CircuitBuilderStage::Mock => {
+            builder.config(k, Some(20));
+            RangeCircuitBuilder::mock(builder)
+        }
+        CircuitBuilderStage::Keygen => {
+            builder.config(k, Some(20));
+            RangeCircuitBuilder::keygen(builder)
+        }
+        CircuitBuilderStage::Prover => RangeCircuitBuilder::prover(builder, break_points.unwrap()),
+    }
+}
+
+#[test]
+fn test_secp_sm_random() {
+    let path = "configs/secp256k1/ecdsa_circuit.config";
+    let params: CircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+
+    let circuit = sm_circuit(
+        params,
+        CircuitBuilderStage::Mock,
+        None,
+        Secp256k1Affine::random(OsRng),
+        Fq::random(OsRng),
+    );
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}
+
+#[test]
+fn test_secp_sm_minus_1() {
+    let path = "configs/secp256k1/ecdsa_circuit.config";
+    let params: CircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+
+    let base = Secp256k1Affine::random(OsRng);
+    let mut s = -Fq::one();
+    let mut n = fe_to_biguint(&s);
+    loop {
+        let circuit = sm_circuit(params, CircuitBuilderStage::Mock, None, base, s);
+        MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+        if &n % BigUint::from(2usize) == BigUint::from(0usize) {
+            break;
+        }
+        n /= 2usize;
+        s = biguint_to_fe(&n);
+    }
+}
+
+#[test]
+fn test_secp_sm_0_1() {
+    let path = "configs/secp256k1/ecdsa_circuit.config";
+    let params: CircuitParams = serde_json::from_reader(
+        File::open(path).unwrap_or_else(|e| panic!("{path} does not exist: {e:?}")),
+    )
+    .unwrap();
+
+    let base = Secp256k1Affine::random(OsRng);
+    let s = Fq::zero();
+    let circuit = sm_circuit(params, CircuitBuilderStage::Mock, None, base, s);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+
+    let s = Fq::one();
+    let circuit = sm_circuit(params, CircuitBuilderStage::Mock, None, base, s);
+    MockProver::run(params.degree, &circuit, vec![]).unwrap().assert_satisfied();
+}


### PR DESCRIPTION
* Add tests for MSM where output is identity point
* Previously when true output is identity in MSM, Rust will panic because we invoke `divide_unsafe` with `nonzero / zero`. We have fixed this in `ec_sub_strict` now.

* Previously fixed base scalar multiply would panic when computing `[-1]P` because even though the circuit constraints were correct, it needed to compute `[-1]P + P` for witness generation and this had division by zero issues. This is now fixed by using a generic accumulator point.

* Made similar changes to variable base `scalar_multiply` to handle edge cases and identity point better.