### PR TITLE
feat: `BigPrimeField = ScalarField = FieldExt + Hash`

### DIFF
--- a/halo2-base/src/gates/tests/general.rs
+++ b/halo2-base/src/gates/tests/general.rs
@@ -6,7 +6,6 @@ use crate::gates::{
 use crate::halo2_proofs::{dev::MockProver, halo2curves::bn256::Fr};
 use crate::utils::{BigPrimeField, ScalarField};
 use crate::{Context, QuantumCell::Constant};
-use ff::Field;
 use rand::rngs::OsRng;
 use rayon::prelude::*;
 


### PR DESCRIPTION
For community contributions it's better to have a blanket trait implementation, even if slightly less optimized. Otherwise Rust prevents you from implementing a trait you don't own for a struct you don't own.

Since field structs are usually implemented in halo2curves, it doesn't make sense for them to implement additional halo2-lib traits.