### PR TITLE
[Fix] Overconstraints involving identity point

### DIFF
--- a/halo2-ecc/src/bn254/final_exp.rs
+++ b/halo2-ecc/src/bn254/final_exp.rs
@@ -86,7 +86,7 @@ impl<'chip, F: PrimeField> Fp12Chip<'chip, F> {
                     res = if z == 1 {
                         self.mul(ctx, &res, a)
                     } else {
-                        self.divide_unsafe(ctx, &res, a)
+                        self.divide_unsafe(ctx, &res, a, None)
                     };
                 } else {
                     assert_eq!(z, 1);
@@ -148,11 +148,11 @@ impl<'chip, F: PrimeField> Fp12Chip<'chip, F> {
         g1_num = fp2_chip.sub_no_carry(ctx, &g1_num, &g3_2);
         // can divide without carrying g1_num or g1_denom (I think)
         let g2_4 = fp2_chip.scalar_mul_no_carry(ctx, &g2, 4);
-        let g1_1 = fp2_chip.divide_unsafe(ctx, &g1_num, &g2_4);
+        let g1_1 = fp2_chip.divide_unsafe(ctx, &g1_num, &g2_4, None);
 
         let g4_g5 = fp2_chip.mul_no_carry(ctx, &g4, &g5);
         let g1_num = fp2_chip.scalar_mul_no_carry(ctx, &g4_g5, 2);
-        let g1_0 = fp2_chip.divide_unsafe(ctx, &g1_num, &g3);
+        let g1_0 = fp2_chip.divide_unsafe(ctx, &g1_num, &g3, None);
 
         let g2_is_zero = fp2_chip.is_zero(ctx, &g2);
         // resulting `g1` is already in "carried" format (witness is in `[0, p)`)
@@ -282,7 +282,7 @@ impl<'chip, F: PrimeField> Fp12Chip<'chip, F> {
                     res = if z == 1 {
                         self.mul(ctx, &res, &a)
                     } else {
-                        self.divide_unsafe(ctx, &res, &a)
+                        self.divide_unsafe(ctx, &res, &a, None)
                     };
                     // compression is free, so it doesn't hurt (except possibly witness generation runtime) to do it
                     // TODO: alternatively we go from small bits to large to avoid this compression
@@ -379,7 +379,7 @@ impl<'chip, F: PrimeField> Fp12Chip<'chip, F> {
     ) -> <Self as FieldChip<F>>::FieldPoint {
         // a^{q^6} = conjugate of a
         let f1 = self.conjugate(ctx, a.clone());
-        let f2 = self.divide_unsafe(ctx, &f1, a);
+        let f2 = self.divide_unsafe(ctx, &f1, a, None);
         let f3 = self.frobenius_map(ctx, &f2, 2);
         self.mul(ctx, &f3, &f2)
     }

--- a/halo2-ecc/src/bn254/pairing.rs
+++ b/halo2-ecc/src/bn254/pairing.rs
@@ -5,7 +5,7 @@ use crate::halo2_proofs::halo2curves::bn256::{
     G1Affine, G2Affine, FROBENIUS_COEFF_FQ12_C1, SIX_U_PLUS_2_NAF,
 };
 use crate::{
-    ecc::{EcPoint, EccChip},
+    ecc::{AddUnequalMode::Unchecked, EcPoint, EccChip},
     fields::fp12::mul_no_carry_w6,
     fields::{FieldChip, PrimeField},
 };
@@ -268,7 +268,7 @@ pub fn miller_loop_BN<F: PrimeField>(
                 (&R, sign_Q),
                 P,
             );
-            R = ecc_chip.add_unequal(ctx, &R, sign_Q, false);
+            R = ecc_chip.add_unequal(ctx, &R, sign_Q, Unchecked);
         }
         if i == 0 {
             break;
@@ -286,7 +286,7 @@ pub fn miller_loop_BN<F: PrimeField>(
     let Q_1 = twisted_frobenius::<F>(ecc_chip, ctx, Q, &c2, &c3);
     let neg_Q_2 = neg_twisted_frobenius::<F>(ecc_chip, ctx, &Q_1, &c2, &c3);
     f = fp12_multiply_with_line_unequal::<F>(ecc_chip.field_chip(), ctx, &f, (&R, &Q_1), P);
-    R = ecc_chip.add_unequal(ctx, &R, &Q_1, false);
+    R = ecc_chip.add_unequal(ctx, &R, &Q_1, Unchecked);
     f = fp12_multiply_with_line_unequal::<F>(ecc_chip.field_chip(), ctx, &f, (&R, &neg_Q_2), P);
 
     f
@@ -363,7 +363,7 @@ pub fn multi_miller_loop_BN<F: PrimeField>(
                     (r, sign_b),
                     a,
                 );
-                *r = ecc_chip.add_unequal(ctx, r.clone(), sign_b, false);
+                *r = ecc_chip.add_unequal(ctx, r.clone(), sign_b, Unchecked);
             }
         }
         if i == 0 {
@@ -384,7 +384,7 @@ pub fn multi_miller_loop_BN<F: PrimeField>(
         let b_1 = twisted_frobenius(ecc_chip, ctx, b, &c2, &c3);
         let neg_b_2 = neg_twisted_frobenius(ecc_chip, ctx, &b_1, &c2, &c3);
         f = fp12_multiply_with_line_unequal(ecc_chip.field_chip(), ctx, &f, (r, &b_1), a);
-        *r = ecc_chip.add_unequal(ctx, r.clone(), b_1, false);
+        *r = ecc_chip.add_unequal(ctx, r.clone(), b_1, Unchecked);
         f = fp12_multiply_with_line_unequal::<F>(ecc_chip.field_chip(), ctx, &f, (r, &neg_b_2), a);
     }
     f

--- a/halo2-ecc/src/ecc/ecdsa.rs
+++ b/halo2-ecc/src/ecc/ecdsa.rs
@@ -37,9 +37,10 @@ where
     let r_valid = scalar_chip.is_soft_nonzero(ctx, &r);
     let s_valid = scalar_chip.is_soft_nonzero(ctx, &s);
 
+    let s_invalid = scalar_chip.gate().is_zero(ctx, s_valid);
     // compute u1 = m s^{-1} mod n and u2 = r s^{-1} mod n
-    let u1 = scalar_chip.divide_unsafe(ctx, msghash, &s);
-    let u2 = scalar_chip.divide_unsafe(ctx, &r, s);
+    let u1 = scalar_chip.divide_unsafe(ctx, msghash, &s, Some(s_invalid));
+    let u2 = scalar_chip.divide_unsafe(ctx, &r, s, Some(s_invalid));
 
     // compute u1 * G and u2 * pubkey
     let u1_mul = fixed_base::scalar_multiply(

--- a/halo2-ecc/src/ecc/fixed_base.rs
+++ b/halo2-ecc/src/ecc/fixed_base.rs
@@ -197,7 +197,9 @@ where
                 })
                 .collect::<Vec<_>>();
             let bit_window_rev = bits.chunks(window_bits).rev();
+            // As an optimization to avoid first assigning an identity point, we start `curr_point = None` and populate it with the first point we want to add.
             let mut curr_point = None;
+            // We keep a boolean flag `is_identity` to track whether the current point is meant to represent the identity point.
             let mut is_identity = one;
             for (cached_point_window, bit_window) in cached_point_window_rev.zip(bit_window_rev) {
                 let is_zero_window = {

--- a/halo2-ecc/src/ecc/tests.rs
+++ b/halo2-ecc/src/ecc/tests.rs
@@ -37,7 +37,9 @@ fn basic_g1_tests<F: PrimeField>(
     // test add_unequal
     chip.field_chip.enforce_less_than(ctx, P_assigned.x().clone());
     chip.field_chip.enforce_less_than(ctx, Q_assigned.x().clone());
-    let sum = chip.add_unequal(ctx, &P_assigned, &Q_assigned, false);
+    let zero = ctx.load_zero();
+    let sum = chip.add_unequal(ctx, &P_assigned, &Q_assigned, AddUnequalMode::Unchecked);
+    let sum = chip.add_unequal(ctx, &P_assigned, &Q_assigned, AddUnequalMode::Conditional(zero));
     assert_eq!(sum.x.0.truncation.to_bigint(limb_bits), sum.x.0.value);
     assert_eq!(sum.y.0.truncation.to_bigint(limb_bits), sum.y.0.value);
     {

--- a/halo2-ecc/src/fields/fp.rs
+++ b/halo2-ecc/src/fields/fp.rs
@@ -400,6 +400,10 @@ impl<'range, F: PrimeField, Fp: PrimeField> FieldChip<F> for FpChip<'range, F, F
         self.enforce_less_than_p(ctx, b);
     }
 
+    /// Returns `b` if `skip == 0` or `0` otherwise.
+    ///
+    /// # Assumptions
+    /// * `skip` is either 0 or 1
     fn select_or_zero(
         &self,
         ctx: &mut Context<F>,

--- a/halo2-ecc/src/fields/mod.rs
+++ b/halo2-ecc/src/fields/mod.rs
@@ -234,19 +234,15 @@ pub trait FieldChip<F: PrimeField>: Clone + Send + Sync {
     ///
     /// `a, b` must be such that `quot * b - a` without carry does not overflow, where `quot` is the output.
     ///
-    /// If `cond` is None, it will constrain that
+    /// If `skip` is None, it will constrain that
     /// ```ignore
     /// out * b = a (mod p)
     /// ```
     /// Note in the `0 / 0` case any `out` will be accepted. In the case `a != 0, b = 0`, the constraint will be unsatisfiable.
     ///
-    /// If `skip = Some(skip)`, then it will constrain that
-    /// ```ignore
-    /// (1 - skip) * (out * b - a) = 0 (mod p)
-    /// ```
-    /// where it is **assumed** that `skip` is a boolean value.
-    /// In other words, if `skip = 0`, the behavior is the same as above.
-    /// If `skip = 1`, then nothing is constrained.
+    /// If `skip = Some(skip)`, then it is **assumed** that `skip` is a boolean value.
+    /// - If `skip = 0`, the behavior is the same as above.
+    /// - If `skip = 1`, then nothing is constrained.
     fn divide_unsafe(
         &self,
         ctx: &mut Context<F>,
@@ -267,13 +263,9 @@ pub trait FieldChip<F: PrimeField>: Clone + Send + Sync {
     /// ```
     /// Note in the `0 / 0` case any `out` will be accepted. In the case `a != 0, b = 0`, the constraint will be unsatisfiable.
     ///
-    /// If `skip = Some(skip)`, then it will constrain that
-    /// ```ignore
-    /// (1 - skip) * (out * b + a) = 0 (mod p)
-    /// ```
-    /// where it is **assumed** that `skip` is a boolean value.
-    /// In other words, if `skip = 0`, the behavior is the same as above.
-    /// If `skip = 1`, then nothing is constrained.
+    /// If `skip = Some(skip)`, then it is **assumed** that `skip` is a boolean value.
+    /// - If `skip = 0`, the behavior is the same as above.
+    /// - If `skip = 1`, then nothing is constrained.
     fn neg_divide_unsafe(
         &self,
         ctx: &mut Context<F>,
@@ -294,13 +286,9 @@ pub trait FieldChip<F: PrimeField>: Clone + Send + Sync {
     /// ```
     /// Note in the `0 / 0` case any `out` will be accepted. In the case `a != 0, b = 0`, the constraint will be unsatisfiable.
     ///
-    /// If `skip = Some(skip)`, then it will constrain that
-    /// ```ignore
-    /// (1 - skip) * (out * b - (-1)^sgn a) = 0 (mod p)
-    /// ```
-    /// where it is **assumed** that `skip` is a boolean value.
-    /// In other words, if `skip = 0`, the behavior is the same as above.
-    /// If `skip = 1`, then nothing is constrained.
+    /// If `skip = Some(skip)`, then it is **assumed** that `skip` is a boolean value.
+    /// - If `skip = 0`, the behavior is the same as above.
+    /// - If `skip = 1`, then nothing is constrained.
     fn signed_divide_unsafe(
         &self,
         ctx: &mut Context<F>,

--- a/halo2-ecc/src/fields/vector.rs
+++ b/halo2-ecc/src/fields/vector.rs
@@ -344,6 +344,18 @@ where
             self.fp_chip.assert_equal(ctx, a_coeff, b_coeff)
         }
     }
+
+    pub fn select_or_zero<A>(
+        &self,
+        ctx: &mut Context<F>,
+        a: impl IntoIterator<Item = A>,
+        skip: AssignedValue<F>,
+    ) -> FieldVector<FpChip::UnsafeFieldPoint>
+    where
+        A: Into<FpChip::UnsafeFieldPoint>,
+    {
+        FieldVector(a.into_iter().map(|a| self.fp_chip.select_or_zero(ctx, a, skip)).collect())
+    }
 }
 
 #[macro_export]
@@ -490,6 +502,15 @@ macro_rules! impl_field_ext_chip_common {
             let a = a.into();
             let b = b.into();
             self.0.assert_equal(ctx, a, b)
+        }
+
+        fn select_or_zero(
+            &self,
+            ctx: &mut Context<F>,
+            a: impl Into<Self::UnsafeFieldPoint>,
+            skip: AssignedValue<F>,
+        ) -> Self::UnsafeFieldPoint {
+            self.0.select_or_zero(ctx, a.into(), skip)
         }
     };
 }

--- a/halo2-ecc/src/fields/vector.rs
+++ b/halo2-ecc/src/fields/vector.rs
@@ -345,6 +345,10 @@ where
         }
     }
 
+    /// Returns `b` if `skip == 0` or the vector of all zeros otherwise.
+    ///
+    /// # Assumptions
+    /// * `skip` is either 0 or 1
     pub fn select_or_zero<A>(
         &self,
         ctx: &mut Context<F>,
@@ -504,6 +508,10 @@ macro_rules! impl_field_ext_chip_common {
             self.0.assert_equal(ctx, a, b)
         }
 
+        /// Returns `b` if `skip == 0` or `0` otherwise.
+        ///
+        /// # Assumptions
+        /// * `skip` is either 0 or 1
         fn select_or_zero(
             &self,
             ctx: &mut Context<F>,


### PR DESCRIPTION
This replaces https://github.com/axiom-crypto/halo2-lib/pull/71, see that PR for details about the problem.

In this new fix, we add an optional `skip` input to `divide_unsafe`:
* If `skip = 1` as a variable, then `divide_unsafe` won't check
  anything, to prevent divide by zero overconstrained panics.
* We propagate this to `ec_{add,sub}_unequal`, with a new enum
  `AddUnequalMode` that generalizes the previous `is_strict` flag. Now
you can pass a conditional `skip` boolean to be passed along to
`divide_unsafe` in cases where you need to prevent divide by zero.

In addition, we discovered some extraneous code here: https://github.com/axiom-crypto/halo2-lib/blob/8b9bdc2ba0d1f6f44e6b313847d2f0268e523c36/halo2-ecc/src/ecc/mod.rs#L232
This is already done in `neg_divide_unsafe` and not necessary!