### PR TITLE
[Fix] scalar multiply completeness

### DIFF
--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -736,7 +736,7 @@ where
         ctx,
         &rand_start_vec[k],
         &rand_start_vec[0],
-        k >= F::CAPACITY as usize,
+        true, // k >= F::CAPACITY as usize, // this assumed random points on `C` were of prime order equal to modulus of `F`. Since this is easily missed, we turn on strict mode always
     );
     let mut curr_point = start_point.clone();
 

--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -501,7 +501,8 @@ where
     assert!(!scalar.is_empty());
     assert!((max_bits as u64) <= modulus::<F>().bits());
     assert!(window_bits != 0);
-
+    multi_scalar_multiply::<F, FC, C>(chip, ctx, &[P], vec![scalar], max_bits, window_bits)
+    /*
     let total_bits = max_bits * scalar.len();
     let num_windows = (total_bits + window_bits - 1) / window_bits;
     let rounded_bitlen = num_windows * window_bits;
@@ -582,6 +583,7 @@ where
     // if at the end, return identity point (0,0) if still not started
     let zero = chip.load_constant(ctx, FC::FieldType::zero());
     ec_select(chip, ctx, curr_point, EcPoint::new(zero.clone(), zero), *is_started.last().unwrap())
+    */
 }
 
 /// Checks that `P` is indeed a point on the elliptic curve `C`.


### PR DESCRIPTION
It is possible in `scalar_multiply` that if `2^window_bits * ceil(scalar / 2^window_bits)` is greater than order of `P` (minus epsilon), there is an overconstraint preventing completeness.

For now we replace `scalar_multiply` with a passthrough to `multi_scalar_multiply`, which does not have this issue.