### PR TITLE
Compatibility with native Poseidon sponge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,10 @@ jobs:
         working-directory: 'halo2-base'
         run: |
           cargo test -- --test-threads=1
+      - name: Run poseidon tests
+        working-directory: 'hashes/poseidon'
+        run: |
+          cargo test test_poseidon_compatibility
       - name: Run halo2-ecc tests MockProver
         working-directory: 'halo2-ecc'
         run: |

--- a/hashes/poseidon/src/lib.rs
+++ b/hashes/poseidon/src/lib.rs
@@ -60,14 +60,9 @@ impl<F: ScalarField, const T: usize, const RATE: usize> PoseidonState<F, T, RATE
         //   to as many elements as inputs are available.
         // - To the first element for which no input is left (if any), an extra 1 is added.
 
-        // ORIGINAL CODE: CAUSED PROBLEMS
-        // self.s[0] =
-        //     gate.sum(ctx, inputs.iter().map(|a| Existing(*a)).chain([Constant(pre_constants[0])]));
-
         // adding preconstant to the distinguished capacity element (only one)
-        // REPLACED BY THIS
-        self.s[0] = ctx.load_witness(*self.s[0].value() + pre_constants[0]);
-
+        self.s[0] = gate.add(ctx, self.s[0], Constant(pre_constants[0]));
+        
         // adding pre-constants and inputs to the elements for which both are available
         for ((x, constant), input) in
             self.s.iter_mut().skip(1).zip(pre_constants.iter().skip(1)).zip(inputs.iter())

--- a/hashes/poseidon/src/lib.rs
+++ b/hashes/poseidon/src/lib.rs
@@ -67,13 +67,15 @@ impl<F: ScalarField, const T: usize, const RATE: usize> PoseidonState<F, T, RATE
         // adding preconstant to the distinguished capacity element (only one)
         // REPLACED BY THIS
         self.s[0] = ctx.load_witness(*self.s[0].value() + pre_constants[0]);
-        
+
+        // adding pre-constants and inputs to the elements for which both are available
         for ((x, constant), input) in
             self.s.iter_mut().skip(1).zip(pre_constants.iter().skip(1)).zip(inputs.iter())
         {
             *x = gate.sum(ctx, [Existing(*x), Existing(*input), Constant(*constant)]);
         }
 
+        // adding only pre-constants when no input is left
         for (i, (x, constant)) in
             self.s.iter_mut().skip(offset).zip(pre_constants.iter().skip(offset)).enumerate()
         {

--- a/hashes/poseidon/src/lib.rs
+++ b/hashes/poseidon/src/lib.rs
@@ -9,6 +9,8 @@ use halo2_base::{
     QuantumCell::{Constant, Existing},
 };
 
+pub mod tests;
+
 struct PoseidonState<F: ScalarField, const T: usize, const RATE: usize> {
     s: [AssignedValue<F>; T],
 }
@@ -62,7 +64,7 @@ impl<F: ScalarField, const T: usize, const RATE: usize> PoseidonState<F, T, RATE
 
         // adding preconstant to the distinguished capacity element (only one)
         self.s[0] = gate.add(ctx, self.s[0], Constant(pre_constants[0]));
-        
+
         // adding pre-constants and inputs to the elements for which both are available
         for ((x, constant), input) in
             self.s.iter_mut().skip(1).zip(pre_constants.iter().skip(1)).zip(inputs.iter())

--- a/hashes/poseidon/src/lib.rs
+++ b/hashes/poseidon/src/lib.rs
@@ -51,9 +51,23 @@ impl<F: ScalarField, const T: usize, const RATE: usize> PoseidonState<F, T, RATE
         assert!(inputs.len() < T);
         let offset = inputs.len() + 1;
 
-        self.s[0] =
-            gate.sum(ctx, inputs.iter().map(|a| Existing(*a)).chain([Constant(pre_constants[0])]));
+        // Explanation of what's going on: before each round of the poseidon permutation,
+        // two things have to be added to the state: inputs (the absorbed elements) and
+        // preconstants. Imagine the state as a list of T elements, the first of which is
+        // the capacity:  |--cap--|--el1--|--el2--|--elR--|
+        // - A preconstant is added to each of all T elements (which is different for each)
+        // - The inputs are added to all elements starting from el1 (so, not to the capacity),
+        //   to as many elements as inputs are available.
+        // - To the first element for which no input is left (if any), an extra 1 is added.
 
+        // ORIGINAL CODE: CAUSED PROBLEMS
+        // self.s[0] =
+        //     gate.sum(ctx, inputs.iter().map(|a| Existing(*a)).chain([Constant(pre_constants[0])]));
+
+        // adding preconstant to the distinguished capacity element (only one)
+        // REPLACED BY THIS
+        self.s[0] = ctx.load_witness(*self.s[0].value() + pre_constants[0]);
+        
         for ((x, constant), input) in
             self.s.iter_mut().skip(1).zip(pre_constants.iter().skip(1)).zip(inputs.iter())
         {

--- a/hashes/poseidon/src/tests.rs
+++ b/hashes/poseidon/src/tests.rs
@@ -24,12 +24,6 @@ mod tests {
         rounds_full: usize,
         rounts_partial: usize,
     ) {
-        // first create proving and verifying key
-        let builder = GateThreadBuilder::<F>::keygen();
-
-        // set env vars
-        builder.config(k as usize, Some(9));
-
         let mut builder = GateThreadBuilder::prover();
         let gate = GateChip::default();
 

--- a/hashes/poseidon/src/tests.rs
+++ b/hashes/poseidon/src/tests.rs
@@ -15,8 +15,6 @@ mod tests {
     // make interleaved calls to absorb and squeeze elements and
     // check that the result is the same in-circuit and natively
     fn poseidon_compatiblity_verification<F: ScalarField, const T: usize, const RATE: usize>(
-        // circuit degree
-        k: u32,
         // elements of F to absorb; one sublist = one absorption
         mut absorptions: Vec<Vec<F>>,
         // list of amounts of elements of F that should be squeezed every time
@@ -92,7 +90,7 @@ mod tests {
         let absorptions = Vec::new();
         let squeezings = random_list_usize(10, 7);
 
-        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+        poseidon_compatiblity_verification::<Fr, 3, 2>(absorptions, squeezings, 8, 57);
     }
 
     #[test]
@@ -100,7 +98,7 @@ mod tests {
         let absorptions = random_nested_list_f(8, 5);
         let squeezings = Vec::new();
 
-        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+        poseidon_compatiblity_verification::<Fr, 3, 2>(absorptions, squeezings, 8, 57);
     }
 
     #[test]
@@ -108,7 +106,7 @@ mod tests {
         let absorptions = random_nested_list_f(10, 5);
         let squeezings = random_list_usize(7, 10);
 
-        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+        poseidon_compatiblity_verification::<Fr, 3, 2>(absorptions, squeezings, 8, 57);
     }
 
     #[test]
@@ -116,6 +114,6 @@ mod tests {
         let absorptions = random_nested_list_f(10, 10);
         let squeezings = random_list_usize(10, 10);
 
-        poseidon_compatiblity_verification::<Fr, 5, 4>(10, absorptions, squeezings, 8, 120);
+        poseidon_compatiblity_verification::<Fr, 5, 4>(absorptions, squeezings, 8, 120);
     }
 }

--- a/hashes/poseidon/src/tests.rs
+++ b/hashes/poseidon/src/tests.rs
@@ -1,0 +1,127 @@
+#[cfg(test)]
+mod tests {
+    use std::{cmp::max, iter::zip};
+
+    use halo2_base::{
+        gates::{builder::GateThreadBuilder, GateChip},
+        halo2_proofs::halo2curves::bn256::Fr,
+        utils::ScalarField,
+    };
+    use poseidon::Poseidon;
+    use rand::Rng;
+
+    use crate::PoseidonChip;
+
+    // make interleaved calls to absorb and squeeze elements and
+    // check that the result is the same in-circuit and natively
+    fn poseidon_compatiblity_verification<F: ScalarField, const T: usize, const RATE: usize>(
+        // circuit degree
+        k: u32,
+        // elements of F to absorb; one sublist = one absorption
+        mut absorptions: Vec<Vec<F>>,
+        // list of amounts of elements of F that should be squeezed every time
+        mut squeezings: Vec<usize>,
+        rounds_full: usize,
+        rounts_partial: usize,
+    ) {
+        // first create proving and verifying key
+        let builder = GateThreadBuilder::<F>::keygen();
+
+        // set env vars
+        builder.config(k as usize, Some(9));
+
+        let mut builder = GateThreadBuilder::prover();
+        let gate = GateChip::default();
+
+        let mut ctx = builder.main(0);
+
+        // constructing native and in-circuit Poseidon sponges
+        let mut native_sponge = Poseidon::<F, T, RATE>::new(rounds_full, rounts_partial);
+        let mut circuit_sponge =
+            PoseidonChip::<F, T, RATE>::new(&mut ctx, rounds_full, rounts_partial)
+                .expect("Failed to construct Poseidon circuit");
+
+        // preparing to interleave absorptions and squeezings
+        let n_iterations = max(absorptions.len(), squeezings.len());
+        absorptions.resize(n_iterations, Vec::new());
+        squeezings.resize(n_iterations, 0);
+
+        for (absorption, squeezing) in zip(absorptions, squeezings) {
+            // absorb (if any elements were provided)
+            native_sponge.update(&absorption);
+            circuit_sponge.update(&ctx.assign_witnesses(absorption));
+
+            // squeeze (if any elements were requested)
+            for _ in 0..squeezing {
+                let native_squeezed = native_sponge.squeeze();
+                let circuit_squeezed =
+                    circuit_sponge.squeeze(&mut ctx, &gate).expect("Failed to squeeze");
+
+                assert_eq!(native_squeezed, *circuit_squeezed.value());
+            }
+        }
+
+        // even if no squeezings were requested, we squeeze to verify the
+        // states are the same after all absorptions
+        let native_squeezed = native_sponge.squeeze();
+        let circuit_squeezed = circuit_sponge.squeeze(&mut ctx, &gate).expect("Failed to squeeze");
+
+        assert_eq!(native_squeezed, *circuit_squeezed.value());
+    }
+
+    fn random_nested_list_f<F: ScalarField>(len: usize, max_sub_len: usize) -> Vec<Vec<F>> {
+        let mut rng = rand::thread_rng();
+        let mut list = Vec::new();
+        for _ in 0..len {
+            let len = rng.gen_range(0..=max_sub_len);
+            let mut sublist = Vec::new();
+
+            for _ in 0..len {
+                sublist.push(F::random(&mut rng));
+            }
+            list.push(sublist);
+        }
+        list
+    }
+
+    fn random_list_usize(len: usize, max: usize) -> Vec<usize> {
+        let mut rng = rand::thread_rng();
+        let mut list = Vec::new();
+        for _ in 0..len {
+            list.push(rng.gen_range(0..=max));
+        }
+        list
+    }
+
+    #[test]
+    fn test_poseidon_compatibility_squeezing_only() {
+        let absorptions = Vec::new();
+        let squeezings = random_list_usize(10, 7);
+
+        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+    }
+
+    #[test]
+    fn test_poseidon_compatibility_absorbing_only() {
+        let absorptions = random_nested_list_f(8, 5);
+        let squeezings = Vec::new();
+
+        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+    }
+
+    #[test]
+    fn test_poseidon_compatibility_interleaved() {
+        let absorptions = random_nested_list_f(10, 5);
+        let squeezings = random_list_usize(7, 10);
+
+        poseidon_compatiblity_verification::<Fr, 3, 2>(10, absorptions, squeezings, 8, 57);
+    }
+
+    #[test]
+    fn test_poseidon_compatibility_other_params() {
+        let absorptions = random_nested_list_f(10, 10);
+        let squeezings = random_list_usize(10, 10);
+
+        poseidon_compatiblity_verification::<Fr, 5, 4>(10, absorptions, squeezings, 8, 120);
+    }
+}


### PR DESCRIPTION
Closes #95 

This sponge is not compatible with other existing native Poseidon sponges - by native I mean executed directly as Rust code, rather than inside a Halo 2 circuit. Specifically, our native reference is [https://github.com/scroll-tech/poseidon/](https://github.com/scroll-tech/poseidon/).

The issue boils down to [line 54](https://github.com/axiom-crypto/halo2-lib/blob/community-edition/hashes/poseidon/src/lib.rs#L54) of the function `absorb_with_pre_constants`. Judging by other implementations, the input should not be added to the first element of the state (which I interpret as the capacity). Furthermore, the current code skips pre-constant addition to the capacity if the input is empty, which should not be the case.

Replacing the cited line by one which just adds the pre-constant to that first position makes this implementation perfectly compatible with the referenced native sponge. This has been tested in various forms: only squeezing, only absorbing and interleaved absorptions and squeezings. I must admit this tests have only taken place with the standard parameters `T = 3, RATE = 2, ROUNDS_FULL = 8, ROUNDS_PARTIAL = 57`.

