### PR TITLE
feat: add debugging functions

### DIFF
--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -421,10 +421,10 @@ impl<F: ScalarField> Context<F> {
         zero_cell
     }
 
-    #[cfg(test)]
     /// Helper function for debugging using `MockProver`. This adds a constraint that always fails.
     /// The `MockProver` will print out the row, column where it fails, so it serves as a debugging "break point"
     /// so you can add to your code to search for where the actual constraint failure occurs.
+    #[cfg(test)]
     pub fn debug_assert_false(&mut self) {
         let one = self.load_constant(F::one());
         let zero = self.load_zero();

--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -125,6 +125,13 @@ impl<F: ScalarField> AssignedValue<F> {
             _ => unreachable!(), // if trying to fetch an un-evaluated fraction, you will have to do something manual
         }
     }
+
+    /// Debug helper function for writing negative tests. This will change the **witness** value of the assigned cell
+    /// to `prank_value`. It does not change any constraints.
+    #[cfg(test)]
+    pub fn debug_prank(&mut self, prank_value: F) {
+        self.value = Assigned::Trivial(prank_value);
+    }
 }
 
 /// Represents a single thread of an execution trace.
@@ -412,5 +419,15 @@ impl<F: ScalarField> Context<F> {
         let zero_cell = self.load_constant(F::zero());
         self.zero_cell = Some(zero_cell);
         zero_cell
+    }
+
+    #[cfg(test)]
+    /// Helper function for debugging using `MockProver`. This adds a constraint that always fails.
+    /// The `MockProver` will print out the row, column where it fails, so it serves as a debugging "break point"
+    /// so you can add to your code to search for where the actual constraint failure occurs.
+    pub fn debug_assert_false(&mut self) {
+        let one = self.load_constant(F::one());
+        let zero = self.load_zero();
+        self.constrain_equal(&one, &zero);
     }
 }


### PR DESCRIPTION
Functions only available for testing:
* `ctx.debug_assert_false` for debug break point to search for other constrain failures in mock prover
* `assigned_value.debug_prank(prank_value)` to prank witness values for negative tests