### PR TITLE
cleanup: use test-utils for benching

### DIFF
--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -15,6 +15,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"
 getset = "0.1.2"
+ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
 
 # Use Axiom's custom halo2 monorepo for faster proving when feature = "halo2-axiom" is on
 halo2_proofs_axiom = { git = "https://github.com/axiom-crypto/halo2.git", package = "halo2_proofs", optional = true }
@@ -60,7 +61,7 @@ halo2-pse = ["halo2_proofs/circuit-params"]
 halo2-axiom = ["halo2_proofs_axiom"]
 display = []
 profile = ["halo2_proofs_axiom?/profile"]
-test-utils = ["dep:rand"]
+test-utils = ["dep:rand", "ark-std"]
 
 [[bench]]
 name = "mul"
@@ -69,3 +70,7 @@ harness = false
 [[bench]]
 name = "inner_product"
 harness = false
+
+[[example]]
+name = "inner_product"
+features = ["test-utils"]

--- a/halo2-base/benches/inner_product.rs
+++ b/halo2-base/benches/inner_product.rs
@@ -3,14 +3,11 @@ use halo2_base::gates::flex_gate::{GateChip, GateInstructions};
 use halo2_base::halo2_proofs::{
     arithmetic::Field,
     dev::MockProver,
-    halo2curves::bn256::{Bn256, Fr, G1Affine},
+    halo2curves::bn256::{Bn256, Fr},
     plonk::*,
-    poly::kzg::{
-        commitment::{KZGCommitmentScheme, ParamsKZG},
-        multiopen::ProverSHPLONK,
-    },
-    transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    poly::kzg::commitment::ParamsKZG,
 };
+use halo2_base::utils::testing::gen_proof;
 use halo2_base::utils::ScalarField;
 use halo2_base::{Context, QuantumCell::Existing};
 use itertools::Itertools;
@@ -71,16 +68,7 @@ fn bench(c: &mut Criterion) {
                     break_points.clone(),
                 );
 
-                let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-                create_proof::<
-                    KZGCommitmentScheme<Bn256>,
-                    ProverSHPLONK<'_, Bn256>,
-                    Challenge255<G1Affine>,
-                    _,
-                    Blake2bWrite<Vec<u8>, G1Affine, Challenge255<_>>,
-                    _,
-                >(params, pk, &[circuit], &[&[]], OsRng, &mut transcript)
-                .expect("prover should not fail");
+                gen_proof(params, pk, circuit);
             })
         },
     );

--- a/halo2-base/benches/mul.rs
+++ b/halo2-base/benches/mul.rs
@@ -1,15 +1,12 @@
 use halo2_base::gates::builder::{GateThreadBuilder, RangeCircuitBuilder};
 use halo2_base::gates::flex_gate::{GateChip, GateInstructions};
 use halo2_base::halo2_proofs::{
-    halo2curves::bn256::{Bn256, Fr, G1Affine},
+    halo2curves::bn256::{Bn256, Fr},
     halo2curves::ff::Field,
     plonk::*,
-    poly::kzg::{
-        commitment::{KZGCommitmentScheme, ParamsKZG},
-        multiopen::ProverGWC,
-    },
-    transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    poly::kzg::commitment::ParamsKZG,
 };
+use halo2_base::utils::testing::gen_proof;
 use halo2_base::utils::ScalarField;
 use halo2_base::Context;
 use rand::rngs::OsRng;
@@ -62,16 +59,7 @@ fn bench(c: &mut Criterion) {
                     break_points.clone(),
                 );
 
-                let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-                create_proof::<
-                    KZGCommitmentScheme<Bn256>,
-                    ProverGWC<'_, Bn256>,
-                    Challenge255<G1Affine>,
-                    _,
-                    Blake2bWrite<Vec<u8>, G1Affine, Challenge255<_>>,
-                    _,
-                >(params, pk, &[circuit], &[&[]], OsRng, &mut transcript)
-                .unwrap();
+                gen_proof(params, pk, circuit);
             })
         },
     );

--- a/halo2-base/examples/inner_product.rs
+++ b/halo2-base/examples/inner_product.rs
@@ -1,13 +1,8 @@
-use halo2_base::gates::builder::{GateThreadBuilder, RangeCircuitBuilder};
+#![cfg(feature = "test-utils")]
 use halo2_base::gates::flex_gate::{GateChip, GateInstructions};
-use halo2_base::halo2_proofs::{
-    arithmetic::Field,
-    dev::MockProver,
-    halo2curves::bn256::{Bn256, Fr},
-    plonk::*,
-    poly::kzg::commitment::ParamsKZG,
-};
-use halo2_base::utils::testing::{check_proof, gen_proof};
+use halo2_base::halo2_proofs::{arithmetic::Field, halo2curves::bn256::Fr};
+use halo2_base::safe_types::RangeInstructions;
+use halo2_base::utils::testing::base_test;
 use halo2_base::utils::ScalarField;
 use halo2_base::{Context, QuantumCell::Existing};
 use itertools::Itertools;
@@ -15,40 +10,30 @@ use rand::rngs::OsRng;
 
 const K: u32 = 19;
 
-fn inner_prod_bench<F: ScalarField>(ctx: &mut Context<F>, a: Vec<F>, b: Vec<F>) {
+fn inner_prod_bench<F: ScalarField>(
+    ctx: &mut Context<F>,
+    gate: &GateChip<F>,
+    a: Vec<F>,
+    b: Vec<F>,
+) {
     assert_eq!(a.len(), b.len());
     let a = ctx.assign_witnesses(a);
     let b = ctx.assign_witnesses(b);
 
-    let chip = GateChip::default();
     for _ in 0..(1 << K) / 16 - 10 {
-        chip.inner_product(ctx, a.clone(), b.clone().into_iter().map(Existing));
+        gate.inner_product(ctx, a.clone(), b.clone().into_iter().map(Existing));
     }
 }
 
 fn main() {
-    let k = 10u32;
-    // create circuit for keygen
-    let mut builder = GateThreadBuilder::new(false);
-    inner_prod_bench(builder.main(0), vec![Fr::zero(); 5], vec![Fr::zero(); 5]);
-    let config_params = builder.config(k as usize, Some(20));
-    let circuit = RangeCircuitBuilder::mock(builder, config_params.clone());
-
-    // check the circuit is correct just in case
-    MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
-
-    let params = ParamsKZG::<Bn256>::setup(k, OsRng);
-    let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
-    let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
-
-    let break_points = circuit.0.break_points.take();
-
-    let mut builder = GateThreadBuilder::new(true);
-    let a = (0..5).map(|_| Fr::random(OsRng)).collect_vec();
-    let b = (0..5).map(|_| Fr::random(OsRng)).collect_vec();
-    inner_prod_bench(builder.main(0), a, b);
-    let circuit = RangeCircuitBuilder::prover(builder, config_params, break_points);
-
-    let proof = gen_proof(&params, &pk, circuit);
-    check_proof(&params, pk.get_vk(), &proof, true);
+    base_test().k(12).bench_builder(
+        (vec![Fr::ZERO; 5], vec![Fr::ZERO; 5]),
+        (
+            (0..5).map(|_| Fr::random(OsRng)).collect_vec(),
+            (0..5).map(|_| Fr::random(OsRng)).collect_vec(),
+        ),
+        |builder, range, (a, b)| {
+            inner_prod_bench(builder.main(0), range.gate(), a, b);
+        },
+    );
 }

--- a/halo2-base/examples/inner_product.rs
+++ b/halo2-base/examples/inner_product.rs
@@ -3,17 +3,11 @@ use halo2_base::gates::flex_gate::{GateChip, GateInstructions};
 use halo2_base::halo2_proofs::{
     arithmetic::Field,
     dev::MockProver,
-    halo2curves::bn256::{Bn256, Fr, G1Affine},
+    halo2curves::bn256::{Bn256, Fr},
     plonk::*,
-    poly::kzg::multiopen::VerifierSHPLONK,
-    poly::kzg::strategy::SingleStrategy,
-    poly::kzg::{
-        commitment::{KZGCommitmentScheme, ParamsKZG},
-        multiopen::ProverSHPLONK,
-    },
-    transcript::{Blake2bRead, TranscriptReadBuffer},
-    transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    poly::kzg::commitment::ParamsKZG,
 };
+use halo2_base::utils::testing::{check_proof, gen_proof};
 use halo2_base::utils::ScalarField;
 use halo2_base::{Context, QuantumCell::Existing};
 use itertools::Itertools;
@@ -55,26 +49,6 @@ fn main() {
     inner_prod_bench(builder.main(0), a, b);
     let circuit = RangeCircuitBuilder::prover(builder, config_params, break_points);
 
-    let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-    create_proof::<
-        KZGCommitmentScheme<Bn256>,
-        ProverSHPLONK<'_, Bn256>,
-        Challenge255<G1Affine>,
-        _,
-        Blake2bWrite<Vec<u8>, G1Affine, Challenge255<_>>,
-        _,
-    >(&params, &pk, &[circuit], &[&[]], OsRng, &mut transcript)
-    .expect("prover should not fail");
-
-    let strategy = SingleStrategy::new(&params);
-    let proof = transcript.finalize();
-    let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-    verify_proof::<
-        KZGCommitmentScheme<Bn256>,
-        VerifierSHPLONK<'_, Bn256>,
-        Challenge255<G1Affine>,
-        Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
-        _,
-    >(&params, pk.get_vk(), strategy, &[&[]], &mut transcript)
-    .unwrap();
+    let proof = gen_proof(&params, &pk, circuit);
+    check_proof(&params, pk.get_vk(), &proof, true);
 }

--- a/halo2-base/src/gates/tests/flex_gate.rs
+++ b/halo2-base/src/gates/tests/flex_gate.rs
@@ -157,9 +157,9 @@ pub fn test_select_from_idx(array: Vec<QuantumCell<Fr>>, idx: QuantumCell<Fr>) -
     base_test().run_gate(|ctx, chip| *chip.select_from_idx(ctx, array, idx).value())
 }
 
-#[test_case(vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]].into_iter().map(|a| a.into_iter().map(Fr::from).collect_vec()).collect_vec(), 
-Fr::from(1) => 
-[4,5,6].map(Fr::from).to_vec(); 
+#[test_case(vec![vec![1,2,3], vec![4,5,6], vec![7,8,9]].into_iter().map(|a| a.into_iter().map(Fr::from).collect_vec()).collect_vec(),
+Fr::from(1) =>
+[4,5,6].map(Fr::from).to_vec();
 "select_array_by_indicator(1): [[1,2,3], [4,5,6], [7,8,9]] -> [4,5,6]")]
 pub fn test_select_array_by_indicator(array2d: Vec<Vec<Fr>>, idx: Fr) -> Vec<Fr> {
     base_test().run_gate(|ctx, chip| {

--- a/halo2-base/src/utils/testing.rs
+++ b/halo2-base/src/utils/testing.rs
@@ -22,7 +22,8 @@ use crate::{
 };
 use rand::{rngs::StdRng, SeedableRng};
 
-/// helper function to generate a proof with real prover
+/// Helper function to generate a proof with real prover using SHPLONK KZG multi-open polynomical commitment scheme
+/// and Blake2b as the hash function for Fiat-Shamir.
 pub fn gen_proof(
     params: &ParamsKZG<Bn256>,
     pk: &ProvingKey<G1Affine>,
@@ -42,7 +43,8 @@ pub fn gen_proof(
     transcript.finalize()
 }
 
-/// helper function to verify a proof
+/// Helper function to verify a proof (generated using [`gen_proof`]) using SHPLONK KZG multi-open polynomical commitment scheme
+/// and Blake2b as the hash function for Fiat-Shamir.
 pub fn check_proof(
     params: &ParamsKZG<Bn256>,
     vk: &VerifyingKey<G1Affine>,
@@ -59,6 +61,7 @@ pub fn check_proof(
         Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
         SingleStrategy<'_, Bn256>,
     >(verifier_params, vk, strategy, &[&[]], &mut transcript);
+    // Just FYI, because strategy is `SingleStrategy`, the output `res` is `Result<(), Error>`, so there is no need to call `res.finalize()`.
 
     if expect_satisfied {
         assert!(res.is_ok());

--- a/halo2-ecc/benches/fixed_base_msm.rs
+++ b/halo2-ecc/benches/fixed_base_msm.rs
@@ -1,21 +1,20 @@
 use ark_std::{end_timer, start_timer};
-use halo2_base::gates::{
-    builder::{
-        BaseConfigParams, CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints,
-        RangeCircuitBuilder,
-    },
-    RangeChip,
-};
 use halo2_base::halo2_proofs::halo2curves::ff::PrimeField as _;
 use halo2_base::halo2_proofs::{
     arithmetic::Field,
     halo2curves::bn256::{Bn256, Fr, G1Affine},
     plonk::*,
-    poly::kzg::{
-        commitment::{KZGCommitmentScheme, ParamsKZG},
-        multiopen::ProverSHPLONK,
+    poly::kzg::commitment::ParamsKZG,
+};
+use halo2_base::{
+    gates::{
+        builder::{
+            BaseConfigParams, CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints,
+            RangeCircuitBuilder,
+        },
+        RangeChip,
     },
-    transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    utils::testing::gen_proof,
 };
 use halo2_ecc::{bn254::FpChip, ecc::EccChip};
 use rand::rngs::OsRng;
@@ -125,16 +124,7 @@ fn bench(c: &mut Criterion) {
                     Some(break_points.clone()),
                 );
 
-                let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-                create_proof::<
-                    KZGCommitmentScheme<Bn256>,
-                    ProverSHPLONK<'_, Bn256>,
-                    Challenge255<G1Affine>,
-                    _,
-                    Blake2bWrite<Vec<u8>, G1Affine, Challenge255<_>>,
-                    _,
-                >(params, pk, &[circuit], &[&[]], &mut rng, &mut transcript)
-                .expect("prover should not fail");
+                gen_proof(params, pk, circuit);
             })
         },
     );

--- a/halo2-ecc/benches/msm.rs
+++ b/halo2-ecc/benches/msm.rs
@@ -1,21 +1,20 @@
 use ark_std::{end_timer, start_timer};
-use halo2_base::gates::{
-    builder::{
-        BaseConfigParams, CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints,
-        RangeCircuitBuilder,
-    },
-    RangeChip,
-};
 use halo2_base::halo2_proofs::halo2curves::ff::PrimeField as _;
 use halo2_base::halo2_proofs::{
     arithmetic::Field,
     halo2curves::bn256::{Bn256, Fr, G1Affine},
     plonk::*,
-    poly::kzg::{
-        commitment::{KZGCommitmentScheme, ParamsKZG},
-        multiopen::ProverSHPLONK,
+    poly::kzg::commitment::ParamsKZG,
+};
+use halo2_base::{
+    gates::{
+        builder::{
+            BaseConfigParams, CircuitBuilderStage, GateThreadBuilder, MultiPhaseThreadBreakPoints,
+            RangeCircuitBuilder,
+        },
+        RangeChip,
     },
-    transcript::{Blake2bWrite, Challenge255, TranscriptWriterBuffer},
+    utils::testing::gen_proof,
 };
 use halo2_ecc::{bn254::FpChip, ecc::EccChip};
 use rand::rngs::OsRng;
@@ -145,16 +144,7 @@ fn bench(c: &mut Criterion) {
                     Some(break_points.clone()),
                 );
 
-                let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-                create_proof::<
-                    KZGCommitmentScheme<Bn256>,
-                    ProverSHPLONK<'_, Bn256>,
-                    Challenge255<G1Affine>,
-                    _,
-                    Blake2bWrite<Vec<u8>, G1Affine, Challenge255<_>>,
-                    _,
-                >(params, pk, &[circuit], &[&[]], &mut rng, &mut transcript)
-                .expect("prover should not fail");
+                gen_proof(params, pk, circuit);
             })
         },
     );

--- a/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
+++ b/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
@@ -16,7 +16,10 @@ use halo2_base::{
         RangeChip,
     },
     halo2_proofs::halo2curves::bn256::G1,
-    utils::fs::gen_srs,
+    utils::{
+        fs::gen_srs,
+        testing::{check_proof, gen_proof},
+    },
 };
 use itertools::Itertools;
 use rand_core::OsRng;
@@ -146,7 +149,6 @@ fn bench_fixed_base_msm() -> Result<(), Box<dyn std::error::Error>> {
             serde_json::from_str(line.unwrap().as_str()).unwrap();
         let k = bench_params.degree;
         println!("---------------------- degree = {k} ------------------------------",);
-        let rng = OsRng;
 
         let params = gen_srs(k);
         println!("{bench_params:?}");
@@ -180,50 +182,13 @@ fn bench_fixed_base_msm() -> Result<(), Box<dyn std::error::Error>> {
             Some(cp),
             Some(break_points),
         );
-        let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
-        create_proof::<
-            KZGCommitmentScheme<Bn256>,
-            ProverSHPLONK<'_, Bn256>,
-            Challenge255<G1Affine>,
-            _,
-            Blake2bWrite<Vec<u8>, G1Affine, Challenge255<G1Affine>>,
-            _,
-        >(&params, &pk, &[circuit], &[&[]], rng, &mut transcript)?;
-        let proof = transcript.finalize();
+        let proof = gen_proof(&params, &pk, circuit);
         end_timer!(proof_time);
 
-        let proof_size = {
-            let path = format!(
-                "data/
-                msm_circuit_proof_{}_{}_{}_{}_{}_{}_{}_{}.data",
-                bench_params.degree,
-                bench_params.num_advice,
-                bench_params.num_lookup_advice,
-                bench_params.num_fixed,
-                bench_params.lookup_bits,
-                bench_params.limb_bits,
-                bench_params.num_limbs,
-                bench_params.batch_size,
-            );
-            let mut fd = File::create(&path)?;
-            fd.write_all(&proof)?;
-            let size = fd.metadata().unwrap().len();
-            fs::remove_file(path)?;
-            size
-        };
+        let proof_size = proof.len();
 
         let verify_time = start_timer!(|| "Verify time");
-        let verifier_params = params.verifier_params();
-        let strategy = SingleStrategy::new(&params);
-        let mut transcript = Blake2bRead::<_, _, Challenge255<_>>::init(&proof[..]);
-        verify_proof::<
-            KZGCommitmentScheme<Bn256>,
-            VerifierSHPLONK<'_, Bn256>,
-            Challenge255<G1Affine>,
-            Blake2bRead<&[u8], G1Affine, Challenge255<G1Affine>>,
-            SingleStrategy<'_, Bn256>,
-        >(verifier_params, pk.get_vk(), strategy, &[&[]], &mut transcript)
-        .unwrap();
+        check_proof(&params, pk.get_vk(), &proof, true);
         end_timer!(verify_time);
 
         writeln!(


### PR DESCRIPTION
- Reduce code bloat in benchmarks by using `gen_proof` and `check_proof` helper functions
- Add initial version of `bench_builder` helper function. Future benches should use this to save even more code.