### PR TITLE
[feat] Keccak Raw Output

### DIFF
--- a/hashes/zkevm/Cargo.toml
+++ b/hashes/zkevm/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4"
 num-bigint = { version = "0.4" }
 halo2-base = { path = "../../halo2-base", default-features = false }
 rayon = "1.7"
+sha3 = "0.10.8"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/hashes/zkevm/src/keccak/keccak_packed_multi.rs
+++ b/hashes/zkevm/src/keccak/keccak_packed_multi.rs
@@ -141,8 +141,7 @@ pub struct KeccakTable {
     pub input_rlc: Column<Advice>, // RLC of input bytes
     // Byte array input length
     pub input_len: Column<Advice>,
-    // /// RLC of the hash result
-    // pub output_rlc: Column<Advice>, // RLC of hash of input bytes
+    /// Output of the hash function
     pub output: Word<Column<Advice>>,
 }
 

--- a/hashes/zkevm/src/keccak/mod.rs
+++ b/hashes/zkevm/src/keccak/mod.rs
@@ -799,6 +799,7 @@ impl<F: Field> KeccakCircuitConfig<F> {
     }
 }
 
+#[allow(dead_code)]
 pub struct KeccakAssignedRow<'v, F: Field> {
     pub(crate) is_final: KeccakAssignedValue<'v, F>,
     pub(crate) length: KeccakAssignedValue<'v, F>,

--- a/hashes/zkevm/src/keccak/mod.rs
+++ b/hashes/zkevm/src/keccak/mod.rs
@@ -1180,7 +1180,7 @@ pub fn keccak_phase0<F: Field>(
                 ));
             }
 
-            // The rlc of the hash
+            // Assign the hash result
             let is_final = is_final_block && round == NUM_ROUNDS;
             hash = if is_final {
                 let hash_bytes_le = s

--- a/hashes/zkevm/src/keccak/tests.rs
+++ b/hashes/zkevm/src/keccak/tests.rs
@@ -18,8 +18,11 @@ use crate::halo2_proofs::{
         Blake2bRead, Blake2bWrite, Challenge255, TranscriptReadBuffer, TranscriptWriterBuffer,
     },
 };
-use halo2_base::{halo2_proofs::halo2curves::ff::FromUniformBytes, SKIP_FIRST_PASS};
+use halo2_base::{
+    halo2_proofs::halo2curves::ff::FromUniformBytes, utils::value_to_option, SKIP_FIRST_PASS,
+};
 use rand_core::OsRng;
+use sha3::{Digest, Keccak256};
 use test_case::test_case;
 
 /// KeccakCircuit
@@ -28,6 +31,7 @@ pub struct KeccakCircuit<F: Field> {
     config: KeccakConfigParams,
     inputs: Vec<Vec<u8>>,
     num_rows: Option<usize>,
+    verify_output: bool,
     _marker: PhantomData<F>,
 }
 
@@ -78,17 +82,45 @@ impl<F: Field> Circuit<F> for KeccakCircuit<F> {
                     self.num_rows.map(|nr| get_keccak_capacity(nr, params.rows_per_round)),
                     params,
                 );
-                let lengths = config.assign(&mut region, &witness);
-                // only look at last row in each round
-                // first round is dummy, so ignore
-                // only look at last round per absorb of RATE_IN_BITS
-                for length in lengths
-                    .into_iter()
-                    .step_by(config.parameters.rows_per_round)
-                    .step_by(NUM_ROUNDS + 1)
-                    .skip(1)
-                {
-                    println!("len: {:?}", length.value());
+                let assigned_rows = config.assign(&mut region, &witness);
+                if self.verify_output {
+                    let mut input_offset = 0;
+                    // only look at last row in each round
+                    // first round is dummy, so ignore
+                    // only look at last round per absorb of RATE_IN_BITS
+                    for assigned_row in assigned_rows
+                        .into_iter()
+                        .step_by(config.parameters.rows_per_round)
+                        .step_by(NUM_ROUNDS + 1)
+                        .skip(1)
+                    {
+                        let KeccakAssignedRow { is_final, length, hash_lo, hash_hi } = assigned_row;
+                        let is_final_val = extract_value(is_final).ne(&F::ZERO);
+                        let hash_lo_val = u128::from_le_bytes(
+                            extract_value(hash_lo).to_bytes_le()[..16].try_into().unwrap(),
+                        );
+                        let hash_hi_val = u128::from_le_bytes(
+                            extract_value(hash_hi).to_bytes_le()[..16].try_into().unwrap(),
+                        );
+                        println!(
+                            "is_final: {:?}, len: {:?}, hash_lo: {:#x}, hash_hi: {:#x}",
+                            is_final_val,
+                            length.value(),
+                            hash_lo_val,
+                            hash_hi_val,
+                        );
+
+                        if input_offset < self.inputs.len() && is_final_val {
+                            // out is in big endian.
+                            let out = Keccak256::digest(&self.inputs[input_offset]);
+                            let lo = u128::from_be_bytes(out[16..].try_into().unwrap());
+                            let hi = u128::from_be_bytes(out[..16].try_into().unwrap());
+                            println!("lo: {:#x}, hi: {:#x}", lo, hi);
+                            assert_eq!(lo, hash_lo_val);
+                            assert_eq!(hi, hash_hi_val);
+                            input_offset += 1;
+                        }
+                    }
                 }
 
                 #[cfg(feature = "halo2-axiom")]
@@ -115,8 +147,13 @@ impl<F: Field> Circuit<F> for KeccakCircuit<F> {
 
 impl<F: Field> KeccakCircuit<F> {
     /// Creates a new circuit instance
-    pub fn new(config: KeccakConfigParams, num_rows: Option<usize>, inputs: Vec<Vec<u8>>) -> Self {
-        KeccakCircuit { config, inputs, num_rows, _marker: PhantomData }
+    pub fn new(
+        config: KeccakConfigParams,
+        num_rows: Option<usize>,
+        inputs: Vec<Vec<u8>>,
+        verify_output: bool,
+    ) -> Self {
+        KeccakCircuit { config, inputs, num_rows, _marker: PhantomData, verify_output }
     }
 }
 
@@ -126,10 +163,19 @@ fn verify<F: Field + Ord + FromUniformBytes<64>>(
     _success: bool,
 ) {
     let k = config.k;
-    let circuit = KeccakCircuit::new(config, Some(2usize.pow(k) - 109), inputs);
+    let circuit = KeccakCircuit::new(config, Some(2usize.pow(k) - 109), inputs, true);
 
     let prover = MockProver::<F>::run(k, &circuit, vec![]).unwrap();
     prover.assert_satisfied();
+}
+
+fn extract_value<'v, F: Field>(assigned_value: KeccakAssignedValue<'v, F>) -> F {
+    let assigned = **value_to_option(assigned_value.value()).unwrap();
+    match assigned {
+        halo2_base::halo2_proofs::plonk::Assigned::Zero => F::ZERO,
+        halo2_base::halo2_proofs::plonk::Assigned::Trivial(f) => f,
+        _ => panic!("value should be trival"),
+    }
 }
 
 #[test_case(14, 28; "k: 14, rows_per_round: 28")]
@@ -160,8 +206,12 @@ fn packed_multi_keccak_prover(k: u32, rows_per_round: usize) {
         (0u8..136).collect::<Vec<_>>(),
         (0u8..200).collect::<Vec<_>>(),
     ];
-    let circuit =
-        KeccakCircuit::new(KeccakConfigParams { k, rows_per_round }, Some(2usize.pow(k)), inputs);
+    let circuit = KeccakCircuit::new(
+        KeccakConfigParams { k, rows_per_round },
+        Some(2usize.pow(k)),
+        inputs,
+        false,
+    );
 
     let vk = keygen_vk(&params, &circuit).unwrap();
     let pk = keygen_pk(&params, vk, &circuit).unwrap();

--- a/hashes/zkevm/src/util/constraint_builder.rs
+++ b/hashes/zkevm/src/util/constraint_builder.rs
@@ -1,4 +1,4 @@
-use super::expression::Expr;
+use super::{expression::Expr, word::Word};
 use crate::halo2_proofs::{halo2curves::ff::PrimeField, plonk::Expression};
 
 #[derive(Default)]
@@ -15,6 +15,18 @@ impl<F: PrimeField> BaseConstraintBuilder<F> {
 
     pub(crate) fn require_zero(&mut self, name: &'static str, constraint: Expression<F>) {
         self.add_constraint(name, constraint);
+    }
+
+    pub(crate) fn require_equal_word(
+        &mut self,
+        name: &'static str,
+        lhs: Word<Expression<F>>,
+        rhs: Word<Expression<F>>,
+    ) {
+        let (lhs_lo, lhs_hi) = lhs.to_lo_hi();
+        let (rhs_lo, rhs_hi) = rhs.to_lo_hi();
+        self.add_constraint(name, lhs_lo - rhs_lo);
+        self.add_constraint(name, lhs_hi - rhs_hi);
     }
 
     pub(crate) fn require_equal(

--- a/hashes/zkevm/src/util/expression.rs
+++ b/hashes/zkevm/src/util/expression.rs
@@ -118,6 +118,31 @@ pub mod select {
     }
 }
 
+/// Decodes a field element from its byte representation in little endian order
+pub mod from_bytes {
+    use super::{Expr, Expression, PrimeField};
+
+    pub fn expr<F: PrimeField, E: Expr<F>>(bytes: &[E]) -> Expression<F> {
+        let mut value = 0.expr();
+        let mut multiplier = F::ONE;
+        for byte in bytes.iter() {
+            value = value + byte.expr() * multiplier;
+            multiplier *= F::from(256);
+        }
+        value
+    }
+
+    pub fn value<F: PrimeField>(bytes: &[u8]) -> F {
+        let mut value = F::ZERO;
+        let mut multiplier = F::ONE;
+        for byte in bytes.iter() {
+            value += F::from(*byte as u64) * multiplier;
+            multiplier *= F::from(256);
+        }
+        value
+    }
+}
+
 /// Trait that implements functionality to get a constant expression from
 /// commonly used types.
 pub trait Expr<F: PrimeField> {
@@ -172,18 +197,6 @@ impl<F: PrimeField> Expr<F> for i32 {
             F::from(self.unsigned_abs() as u64) * if self.is_negative() { -F::ONE } else { F::ONE },
         )
     }
-}
-
-/// Given a bytes-representation of an expression, it computes and returns the
-/// single expression.
-pub fn expr_from_bytes<F: PrimeField, E: Expr<F>>(bytes: &[E]) -> Expression<F> {
-    let mut value = 0.expr();
-    let mut multiplier = F::ONE;
-    for byte in bytes.iter() {
-        value = value + byte.expr() * multiplier;
-        multiplier *= F::from(256);
-    }
-    value
 }
 
 /// Returns 2**by as PrimeField

--- a/hashes/zkevm/src/util/mod.rs
+++ b/hashes/zkevm/src/util/mod.rs
@@ -1,3 +1,4 @@
 pub mod constraint_builder;
 pub mod eth_types;
 pub mod expression;
+pub mod word;

--- a/hashes/zkevm/src/util/word.rs
+++ b/hashes/zkevm/src/util/word.rs
@@ -1,0 +1,328 @@
+//! Define generic Word type with utility functions
+// Naming Convesion
+// - Limbs: An EVM word is 256 bits **big-endian**. Limbs N means split 256 into N limb. For example, N = 4, each
+//   limb is 256/4 = 64 bits
+
+use super::{
+    eth_types::{self, Field, ToLittleEndian, H160, H256},
+    expression::{from_bytes, not, or, Expr},
+};
+use crate::halo2_proofs::{
+    circuit::Value,
+    plonk::{Advice, Column, Expression, VirtualCells},
+    poly::Rotation,
+};
+use itertools::Itertools;
+
+/// evm word 32 bytes, half word 16 bytes
+const N_BYTES_HALF_WORD: usize = 16;
+
+/// The EVM word for witness
+#[derive(Clone, Debug, Copy)]
+pub struct WordLimbs<T, const N: usize> {
+    /// The limbs of this word.
+    pub limbs: [T; N],
+}
+
+pub(crate) type Word2<T> = WordLimbs<T, 2>;
+
+#[allow(dead_code)]
+pub(crate) type Word4<T> = WordLimbs<T, 4>;
+
+#[allow(dead_code)]
+pub(crate) type Word32<T> = WordLimbs<T, 32>;
+
+impl<T, const N: usize> WordLimbs<T, N> {
+    /// Constructor
+    pub fn new(limbs: [T; N]) -> Self {
+        Self { limbs }
+    }
+    /// The number of limbs
+    pub fn n() -> usize {
+        N
+    }
+}
+
+impl<const N: usize> WordLimbs<Column<Advice>, N> {
+    /// Query advice of WordLibs of columns advice
+    pub fn query_advice<F: Field>(
+        &self,
+        meta: &mut VirtualCells<F>,
+        at: Rotation,
+    ) -> WordLimbs<Expression<F>, N> {
+        WordLimbs::new(self.limbs.map(|column| meta.query_advice(column, at)))
+    }
+}
+
+impl<const N: usize> WordLimbs<u8, N> {
+    /// Convert WordLimbs of u8 to WordLimbs of expressions
+    pub fn to_expr<F: Field>(&self) -> WordLimbs<Expression<F>, N> {
+        WordLimbs::new(self.limbs.map(|v| Expression::Constant(F::from(v as u64))))
+    }
+}
+
+impl<T: Default, const N: usize> Default for WordLimbs<T, N> {
+    fn default() -> Self {
+        Self { limbs: [(); N].map(|_| T::default()) }
+    }
+}
+
+impl<F: Field, const N: usize> WordLimbs<F, N> {
+    /// Check if zero
+    pub fn is_zero_vartime(&self) -> bool {
+        self.limbs.iter().all(|limb| limb.is_zero_vartime())
+    }
+}
+
+/// Get the word expression
+pub trait WordExpr<F> {
+    /// Get the word expression
+    fn to_word(&self) -> Word<Expression<F>>;
+}
+
+/// `Word`, special alias for Word2.
+#[derive(Clone, Debug, Copy, Default)]
+pub struct Word<T>(Word2<T>);
+
+impl<T: Clone> Word<T> {
+    /// Construct the word from 2 limbs
+    pub fn new(limbs: [T; 2]) -> Self {
+        Self(WordLimbs::<T, 2>::new(limbs))
+    }
+    /// The high 128 bits limb
+    pub fn hi(&self) -> T {
+        self.0.limbs[1].clone()
+    }
+    /// the low 128 bits limb
+    pub fn lo(&self) -> T {
+        self.0.limbs[0].clone()
+    }
+    /// number of limbs
+    pub fn n() -> usize {
+        2
+    }
+    /// word to low and high 128 bits
+    pub fn to_lo_hi(&self) -> (T, T) {
+        (self.0.limbs[0].clone(), self.0.limbs[1].clone())
+    }
+
+    /// Extract (move) lo and hi values
+    pub fn into_lo_hi(self) -> (T, T) {
+        let [lo, hi] = self.0.limbs;
+        (lo, hi)
+    }
+
+    /// Wrap `Word` into `Word<Value>`
+    pub fn into_value(self) -> Word<Value<T>> {
+        let [lo, hi] = self.0.limbs;
+        Word::new([Value::known(lo), Value::known(hi)])
+    }
+
+    /// Map the word to other types
+    pub fn map<T2: Clone>(&self, mut func: impl FnMut(T) -> T2) -> Word<T2> {
+        Word(WordLimbs::<T2, 2>::new([func(self.lo()), func(self.hi())]))
+    }
+}
+
+impl<T> std::ops::Deref for Word<T> {
+    type Target = WordLimbs<T, 2>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<T: Clone + PartialEq> PartialEq for Word<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.lo() == other.lo() && self.hi() == other.hi()
+    }
+}
+
+impl<F: Field> From<eth_types::Word> for Word<F> {
+    /// Construct the word from u256
+    fn from(value: eth_types::Word) -> Self {
+        let bytes = value.to_le_bytes();
+        Word::new([
+            from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
+            from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
+        ])
+    }
+}
+
+impl<F: Field> From<H256> for Word<F> {
+    /// Construct the word from H256
+    fn from(h: H256) -> Self {
+        let le_bytes = {
+            let mut b = h.to_fixed_bytes();
+            b.reverse();
+            b
+        };
+        Word::new([
+            from_bytes::value(&le_bytes[..N_BYTES_HALF_WORD]),
+            from_bytes::value(&le_bytes[N_BYTES_HALF_WORD..]),
+        ])
+    }
+}
+
+impl<F: Field> From<u64> for Word<F> {
+    /// Construct the word from u64
+    fn from(value: u64) -> Self {
+        let bytes = value.to_le_bytes();
+        Word::new([from_bytes::value(&bytes), F::from(0)])
+    }
+}
+
+impl<F: Field> From<u8> for Word<F> {
+    /// Construct the word from u8
+    fn from(value: u8) -> Self {
+        Word::new([F::from(value as u64), F::from(0)])
+    }
+}
+
+impl<F: Field> From<bool> for Word<F> {
+    fn from(value: bool) -> Self {
+        Word::new([F::from(value as u64), F::from(0)])
+    }
+}
+
+impl<F: Field> From<H160> for Word<F> {
+    /// Construct the word from h160
+    fn from(value: H160) -> Self {
+        let mut bytes = *value.as_fixed_bytes();
+        bytes.reverse();
+        Word::new([
+            from_bytes::value(&bytes[..N_BYTES_HALF_WORD]),
+            from_bytes::value(&bytes[N_BYTES_HALF_WORD..]),
+        ])
+    }
+}
+
+// impl<F: Field> Word<Value<F>> {
+//     /// Assign advice
+//     pub fn assign_advice<A, AR>(
+//         &self,
+//         region: &mut Region<'_, F>,
+//         annotation: A,
+//         column: Word<Column<Advice>>,
+//         offset: usize,
+//     ) -> Result<Word<AssignedCell<F, F>>, Error>
+//     where
+//         A: Fn() -> AR,
+//         AR: Into<String>,
+//     {
+//         let annotation: String = annotation().into();
+//         let lo = region.assign_advice(|| &annotation, column.lo(), offset, || self.lo())?;
+//         let hi = region.assign_advice(|| &annotation, column.hi(), offset, || self.hi())?;
+
+//         Ok(Word::new([lo, hi]))
+//     }
+// }
+
+impl Word<Column<Advice>> {
+    /// Query advice of Word of columns advice
+    pub fn query_advice<F: Field>(
+        &self,
+        meta: &mut VirtualCells<F>,
+        at: Rotation,
+    ) -> Word<Expression<F>> {
+        self.0.query_advice(meta, at).to_word()
+    }
+}
+
+impl<F: Field> Word<Expression<F>> {
+    /// create word from lo limb with hi limb as 0. caller need to guaranteed to be 128 bits.
+    pub fn from_lo_unchecked(lo: Expression<F>) -> Self {
+        Self(WordLimbs::<Expression<F>, 2>::new([lo, 0.expr()]))
+    }
+    /// zero word
+    pub fn zero() -> Self {
+        Self(WordLimbs::<Expression<F>, 2>::new([0.expr(), 0.expr()]))
+    }
+
+    /// one word
+    pub fn one() -> Self {
+        Self(WordLimbs::<Expression<F>, 2>::new([1.expr(), 0.expr()]))
+    }
+
+    /// select based on selector. Here assume selector is 1/0 therefore no overflow check
+    pub fn select<T: Expr<F> + Clone>(
+        selector: T,
+        when_true: Word<T>,
+        when_false: Word<T>,
+    ) -> Word<Expression<F>> {
+        let (true_lo, true_hi) = when_true.to_lo_hi();
+
+        let (false_lo, false_hi) = when_false.to_lo_hi();
+        Word::new([
+            selector.expr() * true_lo.expr() + (1.expr() - selector.expr()) * false_lo.expr(),
+            selector.expr() * true_hi.expr() + (1.expr() - selector.expr()) * false_hi.expr(),
+        ])
+    }
+
+    /// Assume selector is 1/0 therefore no overflow check
+    pub fn mul_selector(&self, selector: Expression<F>) -> Self {
+        Word::new([self.lo() * selector.clone(), self.hi() * selector])
+    }
+
+    /// No overflow check on lo/hi limbs
+    pub fn add_unchecked(self, rhs: Self) -> Self {
+        Word::new([self.lo() + rhs.lo(), self.hi() + rhs.hi()])
+    }
+
+    /// No underflow check on lo/hi limbs
+    pub fn sub_unchecked(self, rhs: Self) -> Self {
+        Word::new([self.lo() - rhs.lo(), self.hi() - rhs.hi()])
+    }
+
+    /// No overflow check on lo/hi limbs
+    pub fn mul_unchecked(self, rhs: Self) -> Self {
+        Word::new([self.lo() * rhs.lo(), self.hi() * rhs.hi()])
+    }
+}
+
+impl<F: Field> WordExpr<F> for Word<Expression<F>> {
+    fn to_word(&self) -> Word<Expression<F>> {
+        self.clone()
+    }
+}
+
+impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
+    /// to_wordlimbs will aggregate nested expressions, which implies during expression evaluation
+    /// it need more recursive call. if the converted limbs word will be used in many places,
+    /// consider create new low limbs word, have equality constrain, then finally use low limbs
+    /// elsewhere.
+    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    pub fn to_word_n<const N2: usize>(&self) -> WordLimbs<Expression<F>, N2> {
+        assert_eq!(N1 % N2, 0);
+        let limbs = self
+            .limbs
+            .chunks(N1 / N2)
+            .map(|chunk| from_bytes::expr(chunk))
+            .collect_vec()
+            .try_into()
+            .unwrap();
+        WordLimbs::<Expression<F>, N2>::new(limbs)
+    }
+
+    /// Equality expression
+    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    pub fn eq<const N2: usize>(&self, others: &WordLimbs<Expression<F>, N2>) -> Expression<F> {
+        assert_eq!(N1 % N2, 0);
+        not::expr(or::expr(
+            self.limbs
+                .chunks(N1 / N2)
+                .map(|chunk| from_bytes::expr(chunk))
+                .zip(others.limbs.clone())
+                .map(|(expr1, expr2)| expr1 - expr2)
+                .collect_vec(),
+        ))
+    }
+}
+
+impl<F: Field, const N1: usize> WordExpr<F> for WordLimbs<Expression<F>, N1> {
+    fn to_word(&self) -> Word<Expression<F>> {
+        Word(self.to_word_n())
+    }
+}
+
+// TODO unittest


### PR DESCRIPTION
- Expose raw keccak results instead of RLCs.
- Import `word.rs` from [PSE zkevm circuits](https://github.com/privacy-scaling-explorations/zkevm-circuits/blob/96b3c4e7a9104413a0a4c22efea6162b9940f0c0/zkevm-circuits/src/util/word.rs).