### PR TITLE
Use `raw_assign_{advice,fixed}` in keccak

### DIFF
--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -18,7 +18,7 @@ getset = "0.1.2"
 ark-std = { version = "0.3.0", features = ["print-trace"], optional = true }
 
 # Use Axiom's custom halo2 monorepo for faster proving when feature = "halo2-axiom" is on
-halo2_proofs_axiom = { git = "https://github.com/axiom-crypto/halo2.git", package = "halo2_proofs", optional = true, branch = "revert_cell_noref" }
+halo2_proofs_axiom = { git = "https://github.com/axiom-crypto/halo2.git", package = "halo2_proofs", optional = true }
 # Use PSE halo2 and halo2curves for compatibility when feature = "halo2-pse" is on
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", rev = "0f00047", optional = true }
 

--- a/hashes/zkevm/src/util/expression.rs
+++ b/hashes/zkevm/src/util/expression.rs
@@ -135,7 +135,7 @@ pub mod from_bytes {
     pub fn value<F: PrimeField>(bytes: &[u8]) -> F {
         let mut value = F::ZERO;
         let mut multiplier = F::ONE;
-        let two_pow_64 = F::from_u128(1 << 64);
+        let two_pow_64 = F::from_u128(1u128 << 64);
         let two_pow_128 = two_pow_64 * two_pow_64;
         for u128_chunk in bytes.chunks(u128::BITS as usize / u8::BITS as usize) {
             let mut buffer = [0; 16];


### PR DESCRIPTION
Now that halo2-base has `raw_assign_{advice,fixed}`, use those instead of `assign_advice_custom`.
I kept `KeccakAssignedValue` as type alias of `Halo2AssignedCell` just to reduce code changes.