### PR TITLE
Generic vertical gate assignment

### DIFF
--- a/halo2-base/src/gates/flex_gate/mod.rs
+++ b/halo2-base/src/gates/flex_gate/mod.rs
@@ -47,6 +47,11 @@ pub struct BasicGateConfig<F: ScalarField> {
 }
 
 impl<F: ScalarField> BasicGateConfig<F> {
+    /// Constructor
+    pub fn new(q_enable: Selector, value: Column<Advice>) -> Self {
+        Self { q_enable, value, _marker: PhantomData }
+    }
+
     /// Instantiates a new [BasicGateConfig].
     ///
     /// Assumes `phase` is in the range [0, MAX_PHASE).
@@ -103,7 +108,7 @@ pub struct FlexGateConfig<F: ScalarField> {
     pub basic_gates: Vec<Vec<BasicGateConfig<F>>>,
     /// A [Vec] of [Fixed] [Column]s for allocating constant values.
     pub constants: Vec<Column<Fixed>>,
-    /// Max number of rows in flex gate.
+    /// Max number of usable rows in the circuit.
     pub max_rows: usize,
 }
 

--- a/halo2-base/src/gates/flex_gate/threads/mod.rs
+++ b/halo2-base/src/gates/flex_gate/threads/mod.rs
@@ -11,7 +11,7 @@
 mod multi_phase;
 mod parallelize;
 /// Thread builder for a single phase
-mod single_phase;
+pub mod single_phase;
 
 pub use multi_phase::{GateStatistics, MultiPhaseCoreManager};
 pub use parallelize::parallelize_core;


### PR DESCRIPTION
`single_phase::assign_with_constraints` can be made generic for any single-column "vertical" gate that uses `ROTATIONS` continguous rows. Currently our calculation of break points assumes that you only "overlap" the gates on the last cell of each rotation window.

This lets us share the `assign_with_constraints` code between `FlexGateConfig` and `RlcConfig` (in axiom-eth)