### PR TITLE
Add `deep_clone` to `BaseCircuitBuilder`

### DIFF
--- a/halo2-base/src/gates/circuit/mod.rs
+++ b/halo2-base/src/gates/circuit/mod.rs
@@ -118,6 +118,14 @@ impl<F: ScalarField> BaseConfig<F> {
             MaybeRangeConfig::WithRange(config) => &config.q_lookup,
         }
     }
+
+    /// Updates the number of usable rows in the circuit. Used if you mutate [ConstraintSystem] after `BaseConfig::configure` is called.
+    pub fn set_usable_rows(&mut self, usable_rows: usize) {
+        match &mut self.base {
+            MaybeRangeConfig::WithoutRange(config) => config.max_rows = usable_rows,
+            MaybeRangeConfig::WithRange(config) => config.gate.max_rows = usable_rows,
+        }
+    }
 }
 
 impl<F: ScalarField> Circuit<F> for BaseCircuitBuilder<F> {

--- a/halo2-base/src/gates/flex_gate/threads/multi_phase.rs
+++ b/halo2-base/src/gates/flex_gate/threads/multi_phase.rs
@@ -44,12 +44,17 @@ impl<F: ScalarField> MultiPhaseCoreManager<F> {
         Self::new(stage.witness_gen_only()).unknown(stage == CircuitBuilderStage::Keygen)
     }
 
-    /// Returns `self` with a given copy manager
-    pub fn use_copy_manager(mut self, copy_manager: SharedCopyConstraintManager<F>) -> Self {
+    /// Mutates `self` to use the given copy manager in all phases and all threads.
+    pub fn set_copy_manager(&mut self, copy_manager: SharedCopyConstraintManager<F>) {
         for pm in &mut self.phase_manager {
-            pm.copy_manager = copy_manager.clone();
+            pm.set_copy_manager(copy_manager.clone());
         }
         self.copy_manager = copy_manager;
+    }
+
+    /// Returns `self` with a given copy manager
+    pub fn use_copy_manager(mut self, copy_manager: SharedCopyConstraintManager<F>) -> Self {
+        self.set_copy_manager(copy_manager);
         self
     }
 

--- a/halo2-base/src/gates/flex_gate/threads/single_phase.rs
+++ b/halo2-base/src/gates/flex_gate/threads/single_phase.rs
@@ -82,6 +82,20 @@ impl<F: ScalarField> SinglePhaseCoreManager<F> {
         Self { use_unknown, ..self }
     }
 
+    /// Mutates `self` to use the given copy manager everywhere, including in all threads.
+    pub fn set_copy_manager(&mut self, copy_manager: SharedCopyConstraintManager<F>) {
+        self.copy_manager = copy_manager.clone();
+        for ctx in &mut self.threads {
+            ctx.copy_manager = copy_manager.clone();
+        }
+    }
+
+    /// Returns `self` with a given copy manager
+    pub fn use_copy_manager(mut self, copy_manager: SharedCopyConstraintManager<F>) -> Self {
+        self.set_copy_manager(copy_manager);
+        self
+    }
+
     /// Returns a mutable reference to the [Context] of a gate thread. Spawns a new thread for the given phase, if none exists.
     pub fn main(&mut self) -> &mut Context<F> {
         if self.threads.is_empty() {


### PR DESCRIPTION
We sometimes want to clone `BaseCircuitBuilder` completely (for example
to re-run witness generation). The derived clone only clones the shared
references, instead of the underlying objects.