### PR TITLE
[feat] App Circuit Utils for Keccak Coprocessor

### DIFF
--- a/halo2-base/src/poseidon/hasher/tests/hasher.rs
+++ b/halo2-base/src/poseidon/hasher/tests/hasher.rs
@@ -1,12 +1,16 @@
 use crate::{
     gates::{range::RangeInstructions, RangeChip},
     halo2_proofs::halo2curves::bn256::Fr,
-    poseidon::hasher::{spec::OptimizedPoseidonSpec, PoseidonCompactInput, PoseidonHasher},
+    poseidon::hasher::{
+        spec::OptimizedPoseidonSpec, PoseidonCompactChunkInput, PoseidonCompactInput,
+        PoseidonHasher,
+    },
     safe_types::SafeTypeChip,
     utils::{testing::base_test, ScalarField},
     Context,
 };
 use halo2_proofs_axiom::arithmetic::Field;
+use itertools::Itertools;
 use pse_poseidon::Poseidon;
 use rand::Rng;
 
@@ -102,6 +106,61 @@ fn hasher_compact_inputs_compatiblity_verification<
     for (compact_output, compact_input) in compact_outputs.iter().zip(compact_inputs) {
         // into() doesn't work if ! is in the beginning in the bool expression...
         let is_not_final_input: bool = compact_input.is_final.as_ref().value().is_zero().into();
+        let is_not_final_output: bool = compact_output.is_final().as_ref().value().is_zero().into();
+        assert_eq!(is_not_final_input, is_not_final_output);
+        if !is_not_final_output {
+            assert_eq!(native_results[output_offset], *compact_output.hash().value());
+            output_offset += 1;
+        }
+    }
+}
+
+// check if the results from hasher and native sponge are same for hash_compact_input.
+fn hasher_compact_chunk_inputs_compatiblity_verification<
+    const T: usize,
+    const RATE: usize,
+    const R_F: usize,
+    const R_P: usize,
+>(
+    payloads: Vec<(Payload<Fr>, bool)>,
+    ctx: &mut Context<Fr>,
+    range: &RangeChip<Fr>,
+) {
+    // Construct in-circuit Poseidon hasher. Assuming SECURE_MDS = 0.
+    let spec = OptimizedPoseidonSpec::<Fr, T, RATE>::new::<R_F, R_P, 0>();
+    let mut hasher = PoseidonHasher::<Fr, T, RATE>::new(spec);
+    hasher.initialize_consts(ctx, range.gate());
+
+    let mut native_results = Vec::with_capacity(payloads.len());
+    let mut chunk_inputs = Vec::<PoseidonCompactChunkInput<Fr, RATE>>::new();
+    let true_witness = SafeTypeChip::unsafe_to_bool(ctx.load_constant(Fr::ONE));
+    let false_witness = SafeTypeChip::unsafe_to_bool(ctx.load_zero());
+
+    // Construct native Poseidon sponge.
+    let mut native_sponge = Poseidon::<Fr, T, RATE>::new(R_F, R_P);
+    for (payload, is_final) in payloads {
+        assert!(payload.values.len() == payload.len);
+        assert!(payload.values.len() % RATE == 0);
+        let inputs = ctx.assign_witnesses(payload.values.clone());
+
+        let is_final_witness = if is_final { true_witness } else { false_witness };
+        chunk_inputs.push(PoseidonCompactChunkInput {
+            inputs: inputs.chunks(RATE).map(|c| c.try_into().unwrap()).collect_vec(),
+            is_final: is_final_witness,
+        });
+        native_sponge.update(&payload.values);
+        if is_final {
+            let native_result = native_sponge.squeeze();
+            native_results.push(native_result);
+            native_sponge = Poseidon::<Fr, T, RATE>::new(R_F, R_P);
+        }
+    }
+    let compact_outputs = hasher.hash_compact_chunk_inputs(ctx, range, &chunk_inputs);
+    assert_eq!(chunk_inputs.len(), compact_outputs.len());
+    let mut output_offset = 0;
+    for (compact_output, chunk_input) in compact_outputs.iter().zip(chunk_inputs) {
+        // into() doesn't work if ! is in the beginning in the bool expression...
+        let is_not_final_input: bool = chunk_input.is_final.as_ref().value().is_zero().into();
         let is_not_final_output: bool = compact_output.is_final().as_ref().value().is_zero().into();
         assert_eq!(is_not_final_input, is_not_final_output);
         if !is_not_final_output {
@@ -232,6 +291,68 @@ fn test_poseidon_hasher_compact_inputs_with_prover() {
         base_test().k(12).bench_builder(init_payloads, logic_payloads, |pool, range, input| {
             let ctx = pool.main();
             hasher_compact_inputs_compatiblity_verification::<T, RATE, 8, 57>(input, ctx, range);
+        });
+    }
+}
+
+#[test]
+fn test_poseidon_hasher_compact_chunk_inputs() {
+    {
+        const T: usize = 3;
+        const RATE: usize = 2;
+        let payloads = vec![
+            (random_payload(RATE * 5, RATE * 5, usize::MAX), true),
+            (random_payload(RATE, RATE, usize::MAX), false),
+            (random_payload(RATE * 2, RATE * 2, usize::MAX), true),
+            (random_payload(RATE * 3, RATE * 3, usize::MAX), true),
+        ];
+        base_test().k(12).run(|ctx, range| {
+            hasher_compact_chunk_inputs_compatiblity_verification::<T, RATE, 8, 57>(
+                payloads, ctx, range,
+            );
+        });
+    }
+    {
+        const T: usize = 3;
+        const RATE: usize = 2;
+        let payloads = vec![
+            (random_payload(0, 0, usize::MAX), true),
+            (random_payload(0, 0, usize::MAX), false),
+            (random_payload(0, 0, usize::MAX), false),
+        ];
+        base_test().k(12).run(|ctx, range| {
+            hasher_compact_chunk_inputs_compatiblity_verification::<T, RATE, 8, 57>(
+                payloads, ctx, range,
+            );
+        });
+    }
+}
+
+#[test]
+fn test_poseidon_hasher_compact_chunk_inputs_with_prover() {
+    {
+        const T: usize = 3;
+        const RATE: usize = 2;
+        let params = [
+            (RATE, false),
+            (RATE * 2, false),
+            (RATE * 5, false),
+            (RATE * 2, true),
+            (RATE * 5, true),
+        ];
+        let init_payloads = params
+            .iter()
+            .map(|(len, is_final)| (random_payload(*len, *len, usize::MAX), *is_final))
+            .collect::<Vec<_>>();
+        let logic_payloads = params
+            .iter()
+            .map(|(len, is_final)| (random_payload(*len, *len, usize::MAX), *is_final))
+            .collect::<Vec<_>>();
+        base_test().k(12).bench_builder(init_payloads, logic_payloads, |pool, range, input| {
+            let ctx = pool.main();
+            hasher_compact_chunk_inputs_compatiblity_verification::<T, RATE, 8, 57>(
+                input, ctx, range,
+            );
         });
     }
 }

--- a/halo2-base/src/poseidon/hasher/tests/hasher.rs
+++ b/halo2-base/src/poseidon/hasher/tests/hasher.rs
@@ -160,10 +160,10 @@ fn hasher_compact_chunk_inputs_compatiblity_verification<
     let mut output_offset = 0;
     for (compact_output, chunk_input) in compact_outputs.iter().zip(chunk_inputs) {
         // into() doesn't work if ! is in the beginning in the bool expression...
-        let is_not_final_input: bool = chunk_input.is_final.as_ref().value().is_zero().into();
-        let is_not_final_output: bool = compact_output.is_final().as_ref().value().is_zero().into();
-        assert_eq!(is_not_final_input, is_not_final_output);
-        if !is_not_final_output {
+        let is_final_input = chunk_input.is_final.as_ref().value();
+        let is_final_output = compact_output.is_final().as_ref().value();
+        assert_eq!(is_final_input, is_final_output);
+        if is_final_output == &Fr::ONE {
             assert_eq!(native_results[output_offset], *compact_output.hash().value());
             output_offset += 1;
         }

--- a/halo2-base/src/safe_types/mod.rs
+++ b/halo2-base/src/safe_types/mod.rs
@@ -228,6 +228,18 @@ impl<'a, F: ScalarField> SafeTypeChip<'a, F> {
         FixLenBytes::<F, MAX_LEN>::new(inputs.map(|input| Self::unsafe_to_byte(input)))
     }
 
+    /// Unsafe method that directly converts `inputs` to [`FixLenBytesVec`] **without any checks**.
+    /// This should **only** be used if an external library needs to convert their types to [`SafeByte`].
+    pub fn unsafe_to_fix_len_bytes_vec(
+        inputs: RawAssignedValues<F>,
+        len: usize,
+    ) -> FixLenBytesVec<F> {
+        FixLenBytesVec::<F>::new(
+            inputs.into_iter().map(|input| Self::unsafe_to_byte(input)).collect_vec(),
+            len,
+        )
+    }
+
     /// Converts a slice of AssignedValue(treated as little-endian) to VarLenBytes.
     ///
     /// * ctx: Circuit [Context]<F> to assign witnesses to.
@@ -249,7 +261,7 @@ impl<'a, F: ScalarField> SafeTypeChip<'a, F> {
     /// * ctx: Circuit [Context]<F> to assign witnesses to.
     /// * inputs: Vector representing the byte array, right padded to `max_len`. See [VarLenBytesVec] for details about padding.
     /// * len: [AssignedValue]<F> witness representing the variable length of the byte array. Constrained to be `<= max_len`.
-    /// * max_len: [usize] representing the maximum length of the byte array and the number of elements it must contain.
+    /// * max_len: [usize] representing the maximum length of the byte array and the number of elements it must contain. We enforce this to be provided explictly to make sure length of `inputs` is determinstic.
     pub fn raw_to_var_len_bytes_vec(
         &self,
         ctx: &mut Context<F>,
@@ -276,6 +288,23 @@ impl<'a, F: ScalarField> SafeTypeChip<'a, F> {
         inputs: [AssignedValue<F>; LEN],
     ) -> FixLenBytes<F, LEN> {
         FixLenBytes::<F, LEN>::new(inputs.map(|input| self.assert_byte(ctx, input)))
+    }
+
+    /// Converts a slice of AssignedValue(treated as little-endian) to FixLenBytesVec.
+    ///
+    /// * ctx: Circuit [Context]<F> to assign witnesses to.
+    /// * inputs: Slice representing the byte array.
+    /// * len: length of the byte array. We enforce this to be provided explictly to make sure length of `inputs` is determinstic.
+    pub fn raw_to_fix_len_bytes_vec(
+        &self,
+        ctx: &mut Context<F>,
+        inputs: RawAssignedValues<F>,
+        len: usize,
+    ) -> FixLenBytesVec<F> {
+        FixLenBytesVec::<F>::new(
+            inputs.into_iter().map(|input| self.assert_byte(ctx, input)).collect_vec(),
+            len,
+        )
     }
 
     fn add_bytes_constraints(

--- a/halo2-base/src/safe_types/tests/bytes.rs
+++ b/halo2-base/src/safe_types/tests/bytes.rs
@@ -55,7 +55,7 @@ fn left_pad_var_len_bytes(mut bytes: Vec<u8>, max_len: usize) -> Vec<u8> {
         let len = ctx.load_witness(Fr::from(len as u64));
         let bytes = safe.raw_to_var_len_bytes_vec(ctx, bytes, len, max_len);
         let padded = bytes.left_pad_to_fixed(ctx, range.gate());
-        padded.iter().map(|b| b.as_ref().value().get_lower_64() as u8).collect()
+        padded.bytes().iter().map(|b| b.as_ref().value().get_lower_64() as u8).collect()
     })
 }
 
@@ -132,13 +132,38 @@ fn neg_var_len_bytes_vec_len_less_than_max_len() {
 
 // Circuit Satisfied for valid inputs
 #[test]
-fn pos_fix_len_bytes_vec() {
+fn pos_fix_len_bytes() {
     base_test().k(10).lookup_bits(8).run(|ctx, range| {
         let safe = SafeTypeChip::new(range);
         let fake_bytes = ctx.assign_witnesses(
             vec![255u64, 255u64, 255u64, 255u64].into_iter().map(Fr::from).collect::<Vec<_>>(),
         );
         safe.raw_to_fix_len_bytes::<4>(ctx, fake_bytes.try_into().unwrap());
+    });
+}
+
+// Assert inputs.len() == len
+#[test]
+#[should_panic]
+fn neg_fix_len_bytes_vec() {
+    base_test().k(10).lookup_bits(8).run(|ctx, range| {
+        let safe = SafeTypeChip::new(range);
+        let fake_bytes = ctx.assign_witnesses(
+            vec![255u64, 255u64, 255u64, 255u64].into_iter().map(Fr::from).collect::<Vec<_>>(),
+        );
+        safe.raw_to_fix_len_bytes_vec(ctx, fake_bytes, 5);
+    });
+}
+
+// Circuit Satisfied for valid inputs
+#[test]
+fn pos_fix_len_bytes_vec() {
+    base_test().k(10).lookup_bits(8).run(|ctx, range| {
+        let safe = SafeTypeChip::new(range);
+        let fake_bytes = ctx.assign_witnesses(
+            vec![255u64, 255u64, 255u64, 255u64].into_iter().map(Fr::from).collect::<Vec<_>>(),
+        );
+        safe.raw_to_fix_len_bytes_vec(ctx, fake_bytes, 4);
     });
 }
 

--- a/hashes/zkevm/src/keccak/coprocessor/circuit/leaf.rs
+++ b/hashes/zkevm/src/keccak/coprocessor/circuit/leaf.rs
@@ -360,7 +360,7 @@ impl<F: Field> KeccakCoprocessorLeafCircuit<F> {
 
         let mut circuit_final_outputs = Vec::with_capacity(loaded_keccak_fs.len());
         for (compact_output, loaded_keccak_f) in
-            lookup_key_per_keccak_f.iter().zip(loaded_keccak_fs)
+            lookup_key_per_keccak_f.iter().zip_eq(loaded_keccak_fs)
         {
             let is_final = AssignedValue::from(loaded_keccak_f.is_final);
             let key = gate.select(ctx, *compact_output.hash(), dummy_key_witness, is_final);
@@ -413,7 +413,7 @@ impl<F: Field> KeccakCoprocessorLeafCircuit<F> {
     }
 }
 
-fn create_hasher<F: Field>() -> PoseidonHasher<F, POSEIDON_T, POSEIDON_RATE> {
+pub(crate) fn create_hasher<F: Field>() -> PoseidonHasher<F, POSEIDON_T, POSEIDON_RATE> {
     // Construct in-circuit Poseidon hasher.
     let spec = OptimizedPoseidonSpec::<F, POSEIDON_T, POSEIDON_RATE>::new::<
         POSEIDON_R_F,
@@ -491,6 +491,7 @@ pub fn encode_inputs_from_keccak_fs<F: Field>(
         last_is_final = is_final.into();
     }
 
+    // TODO: use hash_compact_chunk_input instead.
     let compact_outputs = initialized_hasher.hash_compact_input(ctx, gate, &compact_inputs);
 
     compact_outputs

--- a/hashes/zkevm/src/keccak/coprocessor/encode.rs
+++ b/hashes/zkevm/src/keccak/coprocessor/encode.rs
@@ -2,7 +2,9 @@ use halo2_base::{
     gates::{GateInstructions, RangeInstructions},
     poseidon::hasher::{PoseidonCompactChunkInput, PoseidonHasher},
     safe_types::{FixLenBytesVec, SafeByte, SafeTypeChip, VarLenBytesVec},
+    utils::bit_length,
     AssignedValue, Context,
+    QuantumCell::Constant,
 };
 use itertools::Itertools;
 use num_bigint::BigUint;
@@ -41,7 +43,7 @@ pub fn encode_native_input<F: Field>(bytes: &[u8]) -> F {
     }
     // 1. Split Keccak words into keccak_fs(each keccak_f has NUM_WORDS_TO_ABSORB).
     // 2. Append an extra word into the beginning of each keccak_f. In the first keccak_f, this word is the byte length of the input. Otherwise 0.
-    let words_per_chunk = words
+    let words_per_keccak_f = words
         .chunks(NUM_WORDS_TO_ABSORB)
         .enumerate()
         .map(|(i, chunk)| {
@@ -52,7 +54,7 @@ pub fn encode_native_input<F: Field>(bytes: &[u8]) -> F {
         })
         .collect_vec();
     // Compress every num_word_per_witness words into a witness.
-    let witnesses_per_chunk = words_per_chunk
+    let witnesses_per_keccak_f = words_per_keccak_f
         .iter()
         .map(|chunk| {
             chunk
@@ -68,7 +70,7 @@ pub fn encode_native_input<F: Field>(bytes: &[u8]) -> F {
     // Absorb witnesses keccak_f by keccak_f.
     let mut native_poseidon_sponge =
         pse_poseidon::Poseidon::<F, POSEIDON_T, POSEIDON_RATE>::new(POSEIDON_R_F, POSEIDON_R_P);
-    for witnesses in witnesses_per_chunk {
+    for witnesses in witnesses_per_keccak_f {
         for absorbing in witnesses.chunks(POSEIDON_RATE) {
             // To avoid absorbing witnesses crossing keccak_fs together, pad 0s to make sure absorb.len() == RATE.
             let mut padded_absorb = [F::ZERO; POSEIDON_RATE];
@@ -89,7 +91,7 @@ pub fn encode_var_len_bytes_vec<F: Field>(
     let max_len = bytes.max_len();
     let max_num_keccak_f = get_num_keccak_f(max_len);
     // num_keccak_f = len / NUM_BYTES_TO_ABSORB + 1
-    let num_bits = (usize::BITS - max_len.leading_zeros()) as usize;
+    let num_bits = bit_length(max_len as u64);
     let (num_keccak_f, _) =
         range_chip.div_mod(ctx, *bytes.len(), BigUint::from(NUM_BYTES_TO_ABSORB), num_bits);
     let f_indicator = range_chip.gate().idx_to_indicator(ctx, num_keccak_f, max_num_keccak_f);
@@ -128,7 +130,7 @@ pub fn encode_fix_len_bytes_vec<F: Field>(
     let chunk_input_per_f = format_input(ctx, gate_chip, bytes.bytes(), len_witness);
     let flatten_inputs = chunk_input_per_f
         .into_iter()
-        .flat_map(|chunk_input| chunk_input.into_iter().flat_map(|absorb| absorb))
+        .flat_map(|chunk_input| chunk_input.into_iter().flatten())
         .collect_vec();
 
     initialized_hasher.hash_fix_len_array(ctx, gate_chip, &flatten_inputs)
@@ -197,23 +199,21 @@ fn format_input<F: Field>(
     len: AssignedValue<F>,
 ) -> Vec<Vec<[AssignedValue<F>; POSEIDON_RATE]>> {
     // Constant witnesses
-    let zero_witness = ctx.load_zero();
-    let bytes_to_words_multiplier_witnesses =
-        ctx.load_constants(&get_bytes_to_words_multipliers::<F>());
-    let words_to_witness_multiplier_witnesses =
-        ctx.load_constants(&get_words_to_witness_multipliers::<F>());
+    let zero_const = ctx.load_zero();
+    let bytes_to_words_multipliers_val =
+        get_bytes_to_words_multipliers::<F>().into_iter().map(|m| Constant(m)).collect_vec();
+    let words_to_witness_multipliers_val =
+        get_words_to_witness_multipliers::<F>().into_iter().map(|m| Constant(m)).collect_vec();
 
     let mut bytes_witnesses = bytes.to_vec();
     // Append a zero to the end because An extra keccak_f is performed if len % NUM_BYTES_TO_ABSORB == 0.
-    bytes_witnesses.push(SafeTypeChip::unsafe_to_byte(zero_witness));
+    bytes_witnesses.push(SafeTypeChip::unsafe_to_byte(zero_const));
     let words = bytes_witnesses
         .chunks(NUM_BYTES_PER_WORD)
         .map(|c| {
-            c.iter()
-                .zip(&bytes_to_words_multiplier_witnesses)
-                .fold(zero_witness, |acc, (byte, multiplier)| {
-                    gate.mul_add(ctx, *byte.as_ref(), *multiplier, acc)
-                })
+            let len = c.len();
+            let multipliers = bytes_to_words_multipliers_val[..len].to_vec();
+            gate.inner_product(ctx, c.iter().map(|sb| *sb.as_ref()), multipliers)
         })
         .collect_vec();
 
@@ -221,8 +221,8 @@ fn format_input<F: Field>(
         .chunks(NUM_WORDS_TO_ABSORB)
         .enumerate()
         .map(|(i, words_per_f)| {
-            let mut buffer = [zero_witness; NUM_WORDS_TO_ABSORB + 1];
-            buffer[0] = if i == 0 { len } else { zero_witness };
+            let mut buffer = [zero_const; NUM_WORDS_TO_ABSORB + 1];
+            buffer[0] = if i == 0 { len } else { zero_const };
             buffer[1..words_per_f.len() + 1].copy_from_slice(words_per_f);
             buffer
         })
@@ -234,11 +234,7 @@ fn format_input<F: Field>(
             words
                 .chunks(num_word_per_witness::<F>())
                 .map(|c| {
-                    c.iter()
-                        .zip(&words_to_witness_multiplier_witnesses)
-                        .fold(zero_witness, |acc, (word, multiplier)| {
-                            gate.mul_add(ctx, *word, *multiplier, acc)
-                        })
+                    gate.inner_product(ctx, c.to_vec(), words_to_witness_multipliers_val.clone())
                 })
                 .collect_vec()
         })
@@ -250,7 +246,7 @@ fn format_input<F: Field>(
             words
                 .chunks(POSEIDON_RATE)
                 .map(|c| {
-                    let mut buffer = [zero_witness; POSEIDON_RATE];
+                    let mut buffer = [zero_const; POSEIDON_RATE];
                     buffer[..c.len()].copy_from_slice(c);
                     buffer
                 })

--- a/hashes/zkevm/src/keccak/coprocessor/tests/encode.rs
+++ b/hashes/zkevm/src/keccak/coprocessor/tests/encode.rs
@@ -1,0 +1,124 @@
+use ethers_core::k256::elliptic_curve::Field;
+use halo2_base::{
+    gates::{GateInstructions, RangeChip, RangeInstructions},
+    halo2_proofs::halo2curves::bn256::Fr,
+    safe_types::SafeTypeChip,
+    utils::testing::base_test,
+    Context,
+};
+use itertools::Itertools;
+
+use crate::keccak::coprocessor::{
+    circuit::leaf::create_hasher,
+    encode::{encode_fix_len_bytes_vec, encode_native_input, encode_var_len_bytes_vec},
+};
+
+fn build_and_verify_encode_var_len_bytes_vec(
+    inputs: Vec<(Vec<u8>, usize)>,
+    ctx: &mut Context<Fr>,
+    range_chip: &RangeChip<Fr>,
+) {
+    let mut hasher = create_hasher();
+    hasher.initialize_consts(ctx, range_chip.gate());
+
+    for (input, max_len) in inputs {
+        let expected = encode_native_input::<Fr>(&input);
+        let len = ctx.load_witness(Fr::from(input.len() as u64));
+        let mut witnesses_val = vec![Fr::ZERO; max_len];
+        witnesses_val[..input.len()]
+            .copy_from_slice(&input.iter().map(|b| Fr::from(*b as u64)).collect_vec());
+        let input_witnesses = ctx.assign_witnesses(witnesses_val);
+        let var_len_bytes_vec =
+            SafeTypeChip::unsafe_to_var_len_bytes_vec(input_witnesses, len, max_len);
+        let encoded = encode_var_len_bytes_vec(ctx, range_chip, &hasher, &var_len_bytes_vec);
+        assert_eq!(encoded.value(), &expected);
+    }
+}
+
+fn build_and_verify_encode_fix_len_bytes_vec(
+    inputs: Vec<Vec<u8>>,
+    ctx: &mut Context<Fr>,
+    gate_chip: &impl GateInstructions<Fr>,
+) {
+    let mut hasher = create_hasher();
+    hasher.initialize_consts(ctx, gate_chip);
+
+    for input in inputs {
+        let expected = encode_native_input::<Fr>(&input);
+        let len = input.len();
+        let witnesses_val = input.into_iter().map(|b| Fr::from(b as u64)).collect_vec();
+        let input_witnesses = ctx.assign_witnesses(witnesses_val);
+        let fix_len_bytes_vec = SafeTypeChip::unsafe_to_fix_len_bytes_vec(input_witnesses, len);
+        let encoded = encode_fix_len_bytes_vec(ctx, gate_chip, &hasher, &fix_len_bytes_vec);
+        assert_eq!(encoded.value(), &expected);
+    }
+}
+
+#[test]
+fn mock_encode_var_len_bytes_vec() {
+    let inputs = vec![
+        (vec![], 1),
+        (vec![], 136),
+        ((1u8..135).collect_vec(), 136),
+        ((1u8..135).collect_vec(), 134),
+        ((1u8..135).collect_vec(), 137),
+        ((1u8..135).collect_vec(), 272),
+        ((1u8..135).collect_vec(), 136 * 3),
+    ];
+    base_test().k(18).lookup_bits(4).run(|ctx: &mut Context<Fr>, range_chip: &RangeChip<Fr>| {
+        build_and_verify_encode_var_len_bytes_vec(inputs, ctx, range_chip);
+    })
+}
+
+#[test]
+fn prove_encode_var_len_bytes_vec() {
+    let init_inputs = vec![
+        (vec![], 1),
+        (vec![], 136),
+        (vec![], 136),
+        (vec![], 137),
+        (vec![], 272),
+        (vec![], 136 * 3),
+    ];
+    let inputs = vec![
+        (vec![], 1),
+        (vec![], 136),
+        ((1u8..135).collect_vec(), 136),
+        ((1u8..135).collect_vec(), 137),
+        ((1u8..135).collect_vec(), 272),
+        ((1u8..135).collect_vec(), 136 * 3),
+    ];
+    base_test().k(18).lookup_bits(4).bench_builder(
+        init_inputs,
+        inputs,
+        |core, range_chip, inputs| {
+            let ctx = core.main();
+            build_and_verify_encode_var_len_bytes_vec(inputs, ctx, range_chip);
+        },
+    );
+}
+
+#[test]
+fn mock_encode_fix_len_bytes_vec() {
+    let inputs =
+        vec![vec![], (1u8..135).collect_vec(), (0u8..136).collect_vec(), (0u8..211).collect_vec()];
+    base_test().k(18).lookup_bits(4).run(|ctx: &mut Context<Fr>, range_chip: &RangeChip<Fr>| {
+        build_and_verify_encode_fix_len_bytes_vec(inputs, ctx, range_chip.gate());
+    });
+}
+
+#[test]
+fn prove_encode_fix_len_bytes_vec() {
+    let init_inputs =
+        vec![vec![], (2u8..136).collect_vec(), (1u8..137).collect_vec(), (2u8..213).collect_vec()];
+    let inputs =
+        vec![vec![], (1u8..135).collect_vec(), (0u8..136).collect_vec(), (0u8..211).collect_vec()];
+    base_test().k(18).lookup_bits(4).bench_builder(
+        init_inputs,
+        inputs,
+        |core, range_chip, inputs| {
+            let ctx = core.main();
+            build_and_verify_encode_fix_len_bytes_vec(inputs, ctx, range_chip.gate());
+        },
+    );
+}

--- a/hashes/zkevm/src/keccak/coprocessor/tests/mod.rs
+++ b/hashes/zkevm/src/keccak/coprocessor/tests/mod.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
+mod encode;
+#[cfg(test)]
 mod output;

--- a/hashes/zkevm/src/keccak/vanilla/mod.rs
+++ b/hashes/zkevm/src/keccak/vanilla/mod.rs
@@ -592,7 +592,7 @@ impl<F: Field> KeccakCircuitConfig<F> {
             let mut cb = BaseConstraintBuilder::new(MAX_DEGREE);
             let masked_input_bytes = input_bytes
                 .iter()
-                .zip(is_paddings.clone())
+                .zip_eq(is_paddings.clone())
                 .map(|(input_byte, is_padding)| {
                     input_byte.expr.clone() * not::expr(is_padding.expr().clone())
                 })


### PR DESCRIPTION
- Encoding for `VarLenBytesVec` and `FixLenBytesVec`.