### PR TITLE
feat: use `(TypeId, usize)` instead of `usize` for lookup tag

### DIFF
--- a/halo2-base/src/gates/range/mod.rs
+++ b/halo2-base/src/gates/range/mod.rs
@@ -445,7 +445,7 @@ impl<F: ScalarField> RangeChip<F> {
     fn add_cell_to_lookup(&self, ctx: &Context<F>, a: AssignedValue<F>) {
         let phase = ctx.phase();
         let manager = &self.lookup_manager[phase];
-        manager.add_lookup(ctx.context_id, [a]);
+        manager.add_lookup(ctx.tag(), [a]);
     }
 
     /// Checks and constrains that `a` lies in the range [0, 2<sup>range_bits</sup>).

--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -171,6 +171,7 @@ pub struct Context<F: ScalarField> {
     #[getset(get_copy = "pub")]
     phase: usize,
     /// Identifier for what virtual region this context is in
+    #[getset(get_copy = "pub")]
     type_id: TypeId,
     /// Identifier to reference cells from this [Context].
     context_id: usize,
@@ -218,6 +219,11 @@ impl<F: ScalarField> Context<F> {
     /// The context id, this can be used as a tag when CPU multi-threading
     pub fn id(&self) -> usize {
         self.context_id
+    }
+
+    /// A unique tag that should identify this context across all virtual regions and phases.
+    pub fn tag(&self) -> (TypeId, usize) {
+        (self.type_id, self.context_id)
     }
 
     fn latest_cell(&self) -> ContextCell {

--- a/halo2-base/src/virtual_region/tests/lookups/memory.rs
+++ b/halo2-base/src/virtual_region/tests/lookups/memory.rs
@@ -69,7 +69,7 @@ impl<F: ScalarField, const CYCLES: usize> RAMCircuit<F, CYCLES> {
             let value = self.memory[ptr];
             let ptr = ctx.load_witness(F::from(ptr as u64 + 1));
             let value = ctx.load_witness(value);
-            self.ram.add_lookup(ctx.id(), [ptr, value]);
+            self.ram.add_lookup((ctx.type_id(), ctx.id()), [ptr, value]);
             sum = gate.add(ctx, sum, value);
         }
     }


### PR DESCRIPTION
I was a little worried `context.id()` would not be unique when using multiple phases or managers. Adding `TypeId` should make everything unique.