### PR TITLE
[chore] add conversion `SafePrimitive` to `QuantumCell::Existing`

### DIFF
--- a/halo2-base/src/safe_types/mod.rs
+++ b/halo2-base/src/safe_types/mod.rs
@@ -1,5 +1,5 @@
 use std::{
-    borrow::{Borrow, BorrowMut},
+    borrow::Borrow,
     cmp::{max, min},
 };
 

--- a/halo2-base/src/safe_types/primitives.rs
+++ b/halo2-base/src/safe_types/primitives.rs
@@ -1,3 +1,7 @@
+use std::ops::Deref;
+
+use crate::QuantumCell;
+
 use super::*;
 /// SafeType for bool (1 bit).
 ///
@@ -23,27 +27,29 @@ macro_rules! safe_primitive_impls {
             }
         }
 
-        impl<F: ScalarField> AsMut<AssignedValue<F>> for $SafePrimitive {
-            fn as_mut(&mut self) -> &mut AssignedValue<F> {
-                &mut self.0
-            }
-        }
-
         impl<F: ScalarField> Borrow<AssignedValue<F>> for $SafePrimitive {
             fn borrow(&self) -> &AssignedValue<F> {
                 &self.0
             }
         }
 
-        impl<F: ScalarField> BorrowMut<AssignedValue<F>> for $SafePrimitive {
-            fn borrow_mut(&mut self) -> &mut AssignedValue<F> {
-                &mut self.0
+        impl<F: ScalarField> Deref for $SafePrimitive {
+            type Target = AssignedValue<F>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
             }
         }
 
         impl<F: ScalarField> From<$SafePrimitive> for AssignedValue<F> {
             fn from(safe_primitive: $SafePrimitive) -> Self {
                 safe_primitive.0
+            }
+        }
+
+        impl<F: ScalarField> From<$SafePrimitive> for QuantumCell<F> {
+            fn from(safe_primitive: $SafePrimitive) -> Self {
+                QuantumCell::Existing(safe_primitive.0)
             }
         }
     };


### PR DESCRIPTION
Had to keep writing `*byte.as_ref()` because even though `SafeByte` implements `Into` for `AssignedValue`, it did not auto convert further to `QuantumCell::Existing`. 

Added that conversion to the macro. Also implement `Deref` for `SafeByte` to `AssignedValue`.

Same for `SafeBool`.


Future thought: Not sure if we should just auto-implement conversion of `T: Into<AssignedValue<F>>` into `QuantumCell::Existing`.
