### PR TITLE
chore: add getters to `KeccakComponentShardCircuit`

### DIFF
--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -46,9 +46,11 @@ pub struct KeccakComponentShardCircuit<F: Field> {
     /// Parameters of this circuit. The same parameters always construct the same circuit.
     #[getset(get = "pub")]
     params: KeccakComponentShardCircuitParams,
-
+    #[getset(get = "pub")]
     base_circuit_builder: RefCell<BaseCircuitBuilder<F>>,
+    #[getset(get = "pub")]
     hasher: RefCell<PoseidonHasher<F, POSEIDON_T, POSEIDON_RATE>>,
+    #[getset(get = "pub")]
     gate_chip: GateChip<F>,
 }
 


### PR DESCRIPTION
For example, it's useful to access `BaseCircuitBuilder` to read public instances.