### PR TITLE
[chore] Add getters to `KeccakComponentShardCircuit`

### DIFF
--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -41,16 +41,17 @@ use itertools::Itertools;
 /// Keccak Component Shard Circuit
 #[derive(Getters)]
 pub struct KeccakComponentShardCircuit<F: Field> {
+    /// The multiple inputs to be hashed.
     #[getset(get = "pub")]
     inputs: Vec<Vec<u8>>,
 
     /// Parameters of this circuit. The same parameters always construct the same circuit.
-    #[getset(get = "pub")]
     params: KeccakComponentShardCircuitParams,
-    #[getset(get = "pub")]
     base_circuit_builder: RefCell<BaseCircuitBuilder<F>>,
+    /// Poseidon hasher. Stateless once initialized.
     #[getset(get = "pub")]
     hasher: RefCell<PoseidonHasher<F, POSEIDON_T, POSEIDON_RATE>>,
+    /// Stateless gate chip
     #[getset(get = "pub")]
     gate_chip: GateChip<F>,
 }

--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -46,9 +46,11 @@ pub struct KeccakComponentShardCircuit<F: Field> {
     /// Parameters of this circuit. The same parameters always construct the same circuit.
     #[getset(get = "pub")]
     params: KeccakComponentShardCircuitParams,
-
+    #[getset(get = "pub")]
     base_circuit_builder: RefCell<BaseCircuitBuilder<F>>,
+    #[getset(get = "pub")]
     hasher: RefCell<PoseidonHasher<F, POSEIDON_T, POSEIDON_RATE>>,
+    #[getset(get = "pub")]
     gate_chip: GateChip<F>,
 }
 

--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -41,6 +41,7 @@ use itertools::Itertools;
 /// Keccak Component Shard Circuit
 #[derive(Getters)]
 pub struct KeccakComponentShardCircuit<F: Field> {
+    #[getset(get = "pub")]
     inputs: Vec<Vec<u8>>,
 
     /// Parameters of this circuit. The same parameters always construct the same circuit.


### PR DESCRIPTION
Add getters for:
- `inputs` (necessary to compute public instances)
- `hasher` (in case we want to re-use Poseidon spec)
- `gate_chip` (stateless, so harmless to provide)