### PR TITLE
[chore] fix halo2-pse build error

### DIFF
--- a/halo2-base/src/virtual_region/lookups/basic.rs
+++ b/halo2-base/src/virtual_region/lookups/basic.rs
@@ -86,13 +86,18 @@ impl<const KEY_COL: usize> BasicDynLookupConfig<KEY_COL> {
         rows: impl IntoIterator<Item = [AssignedValue<F>; KEY_COL]>,
         copy_manager: Option<&SharedCopyConstraintManager<F>>,
     ) {
+        #[cfg(not(feature = "halo2-axiom"))]
+        let rows = rows.into_iter().collect::<Vec<_>>();
         layouter
             .assign_region(
                 || "Dynamic Lookup Table",
                 |mut region| {
                     self.assign_virtual_table_to_raw_from_offset(
                         &mut region,
+                        #[cfg(feature = "halo2-axiom")]
                         rows,
+                        #[cfg(not(feature = "halo2-axiom"))]
+                        rows.clone(),
                         0,
                         copy_manager,
                     );


### PR DESCRIPTION
`halo2-pse` `assign_region` takes a `Fn` closure not `FnOnce` because of some layouter stuff. So we have to clone `rows`.