### PR TITLE
[feat] avoid double `meta.query` to same cells

### DIFF
--- a/hashes/zkevm/src/sha256/vanilla/constraints.rs
+++ b/hashes/zkevm/src/sha256/vanilla/constraints.rs
@@ -279,7 +279,7 @@ impl<F: Field> Sha256CircuitConfig<F> {
                 let is_padding_prev = if idx == 0 {
                     prev_is_padding.expr()
                 } else {
-                    is_paddings_expr[idx-1].clone()
+                    is_paddings_expr[idx - 1].clone()
                 };
                 let is_padding = is_paddings_expr[idx].clone();
                 let is_first_padding = is_padding.clone() - is_padding_prev.clone();


### PR DESCRIPTION
Avoid calling `meta.query_*` multiple times on `is_paddings` when you can do it once and then `clone`.