### PR TITLE
[feat] implement `CircuitExt` for `KeccakComponentShardCircuit`

### DIFF
--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -10,7 +10,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 rand_chacha = "0.3"
 rustc-hash = "1.1"
-rayon = "1.7"
+rayon = "1.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4"

--- a/hashes/zkevm/Cargo.toml
+++ b/hashes/zkevm/Cargo.toml
@@ -15,10 +15,10 @@ num-bigint = { version = "0.4" }
 halo2-base = { path = "../../halo2-base", default-features = false, features = [
     "test-utils",
 ] }
-rayon = "1.7"
+rayon = "1.8"
 sha3 = "0.10.8"
-# always included but without features to use Native poseidon
-snark-verifier = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "develop", default-features = false }
+# always included but without features to use Native poseidon and get CircuitExt trait
+snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "develop", default-features = false }
 getset = "0.1.2"
 
 [dev-dependencies]
@@ -35,9 +35,9 @@ test-case = "3.1.0"
 
 [features]
 default = ["halo2-axiom", "display"]
-display = ["halo2-base/display", "snark-verifier/display"]
-halo2-pse = ["halo2-base/halo2-pse", "snark-verifier/halo2-pse"]
-halo2-axiom = ["halo2-base/halo2-axiom", "snark-verifier/halo2-axiom"]
+display = ["snark-verifier-sdk/display"]
+halo2-pse = ["halo2-base/halo2-pse"]
+halo2-axiom = ["halo2-base/halo2-axiom"]
 jemallocator = ["halo2-base/jemallocator"]
 mimalloc = ["halo2-base/mimalloc"]
 asm = ["halo2-base/asm"]

--- a/hashes/zkevm/Cargo.toml
+++ b/hashes/zkevm/Cargo.toml
@@ -15,6 +15,7 @@ num-bigint = { version = "0.4" }
 halo2-base = { path = "../../halo2-base", default-features = false, features = [
     "test-utils",
 ] }
+serde = { version = "1.0", features = ["derive"] }
 rayon = "1.8"
 sha3 = "0.10.8"
 # always included but without features to use Native poseidon and get CircuitExt trait

--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -89,7 +89,7 @@ impl KeccakComponentShardCircuitParams {
     ) -> Self {
         assert!(1 << k > num_unusable_row, "Number of unusable rows must be less than 2^k");
         let max_rows = (1 << k) - num_unusable_row;
-        // Derived from [crate::keccak::native_circuit::keccak_packed_multi::get_keccak_capacity].
+        // Derived from [crate::keccak::vanilla::keccak_packed_multi::get_keccak_capacity].
         let rows_per_round = max_rows / (capacity * (NUM_ROUNDS + 1) + 1 + NUM_WORDS_TO_ABSORB);
         assert!(rows_per_round > 0, "No enough rows for the speficied capacity");
         let keccak_circuit_params = KeccakConfigParams { k: k as u32, rows_per_round };

--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -41,6 +41,7 @@ use halo2_base::{
     QuantumCell::Constant,
 };
 use itertools::Itertools;
+use serde::{Deserialize, Serialize};
 use snark_verifier_sdk::CircuitExt;
 
 /// Keccak Component Shard Circuit
@@ -62,7 +63,7 @@ pub struct KeccakComponentShardCircuit<F: Field> {
 }
 
 /// Parameters of KeccakComponentCircuit.
-#[derive(Default, Clone, CopyGetters)]
+#[derive(Default, Clone, CopyGetters, Serialize, Deserialize)]
 pub struct KeccakComponentShardCircuitParams {
     /// This circuit has 2^k rows.
     #[getset(get_copy = "pub")]

--- a/hashes/zkevm/src/keccak/component/encode.rs
+++ b/hashes/zkevm/src/keccak/component/encode.rs
@@ -8,7 +8,7 @@ use halo2_base::{
 };
 use itertools::Itertools;
 use num_bigint::BigUint;
-use snark_verifier::loader::native::NativeLoader;
+use snark_verifier_sdk::{snark_verifier, NativeLoader};
 
 use crate::{
     keccak::vanilla::{keccak_packed_multi::get_num_keccak_f, param::*},

--- a/hashes/zkevm/src/keccak/component/output.rs
+++ b/hashes/zkevm/src/keccak/component/output.rs
@@ -2,7 +2,7 @@ use super::{encode::encode_native_input, param::*};
 use crate::{keccak::vanilla::keccak_packed_multi::get_num_keccak_f, util::eth_types::Field};
 use itertools::Itertools;
 use sha3::{Digest, Keccak256};
-use snark_verifier::loader::native::NativeLoader;
+use snark_verifier_sdk::{snark_verifier, NativeLoader};
 
 /// Witnesses to be exposed as circuit outputs.
 #[derive(Clone, Copy, PartialEq, Debug)]

--- a/hashes/zkevm/src/keccak/vanilla/mod.rs
+++ b/hashes/zkevm/src/keccak/vanilla/mod.rs
@@ -17,6 +17,7 @@ use halo2_base::utils::halo2::{raw_assign_advice, raw_assign_fixed};
 use itertools::Itertools;
 use log::{debug, info};
 use rayon::prelude::{IntoParallelRefIterator, ParallelIterator};
+use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
 pub mod cell_manager;
@@ -30,7 +31,7 @@ pub mod util;
 pub mod witness;
 
 /// Configuration parameters to define [`KeccakCircuitConfig`]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize)]
 pub struct KeccakConfigParams {
     /// The circuit degree, i.e., circuit has 2<sup>k</sup> rows
     pub k: u32,
@@ -635,7 +636,7 @@ impl<F: Field> KeccakCircuitConfig<F> {
             });
             // Logically here we want !q_input[cur] && !start_new_hash(cur) ==> bytes_left[cur + num_rows_per_round] == bytes_left[cur]
             // In practice, in order to save a degree we use !(q_input[cur] ^ start_new_hash(cur)) ==> bytes_left[cur + num_rows_per_round] == bytes_left[cur]
-            // When q_input[cur] is true, the above constraint q_input[cur] ==> bytes_left[cur + num_rows_per_round] + word_len == bytes_left[cur] has 
+            // When q_input[cur] is true, the above constraint q_input[cur] ==> bytes_left[cur + num_rows_per_round] + word_len == bytes_left[cur] has
             // already been enabled. Even is_final in start_new_hash(cur) is true, it's just over-constrainted.
             // Note: At the first row of any round except the last round, is_final could be either true or false.
             cb.condition(not::expr(q(q_input, meta) + start_new_hash(meta, Rotation::cur())), |cb| {


### PR DESCRIPTION
This is so `KeccakComponentShardCircuit` can be aggregated by `snark-verifier-sdk`. It must be done in this crate to avoid Rust's orphan rule.