### PR TITLE
chore: move `is_final` to `ShaTable`

### DIFF
--- a/hashes/zkevm/src/sha256/vanilla/columns.rs
+++ b/hashes/zkevm/src/sha256/vanilla/columns.rs
@@ -22,6 +22,9 @@ pub struct ShaTable {
     pub io: Column<Advice>,
     /// Length in bytes of the input processed so far. Does not include padding.
     pub length: Column<Advice>,
+    /// Advice to represent if this input block is the last one for a variable length input.
+    /// The advice value should only be used in the last row of each [SHA256_NUM_ROWS] block.
+    pub(super) is_final: Column<Advice>,
 }
 
 impl ShaTable {
@@ -36,7 +39,8 @@ impl ShaTable {
         meta.enable_equality(length);
         meta.enable_equality(hash_lo);
         meta.enable_equality(hash_hi);
-        Self { q_enable, io, length }
+        let is_final = meta.advice_column();
+        Self { q_enable, io, length, is_final }
     }
 }
 
@@ -59,7 +63,6 @@ pub struct Sha256CircuitConfig<F> {
     pub(super) word_w: [Column<Advice>; NUM_BITS_PER_WORD_W],
     pub(super) word_a: [Column<Advice>; NUM_BITS_PER_WORD_EXT],
     pub(super) word_e: [Column<Advice>; NUM_BITS_PER_WORD_EXT],
-    pub(super) is_final: Column<Advice>,
     pub(super) is_paddings: [Column<Advice>; ABSORB_WIDTH_PER_ROW_BYTES],
     pub(super) round_cst: Column<Fixed>,
     pub(super) h_a: Column<Fixed>,

--- a/hashes/zkevm/src/sha256/vanilla/constraints.rs
+++ b/hashes/zkevm/src/sha256/vanilla/constraints.rs
@@ -38,7 +38,6 @@ impl<F: Field> Sha256CircuitConfig<F> {
         let word_w = array_init::array_init(|_| meta.advice_column());
         let word_a = array_init::array_init(|_| meta.advice_column());
         let word_e = array_init::array_init(|_| meta.advice_column());
-        let is_final = meta.advice_column();
         let is_paddings = array_init::array_init(|_| meta.advice_column());
         let round_cst = meta.fixed_column();
         let h_a = meta.fixed_column();
@@ -46,6 +45,7 @@ impl<F: Field> Sha256CircuitConfig<F> {
         let hash_table = ShaTable::construct(meta);
         let length = hash_table.length;
         let q_enable = hash_table.q_enable;
+        let is_final = hash_table.is_final;
 
         // State bits
         let mut w_ext = vec![0u64.expr(); NUM_BITS_PER_WORD_W];
@@ -508,7 +508,6 @@ impl<F: Field> Sha256CircuitConfig<F> {
             word_w,
             word_a,
             word_e,
-            is_final,
             is_paddings,
             round_cst,
             h_a,

--- a/hashes/zkevm/src/sha256/vanilla/witness.rs
+++ b/hashes/zkevm/src/sha256/vanilla/witness.rs
@@ -204,7 +204,7 @@ impl<F: Field> Sha256CircuitConfig<F> {
             F::ZERO
         };
         let [is_final, io, length] = [
-            (self.is_final, F::from(row.is_final)),
+            (self.hash_table.is_final, F::from(row.is_final)),
             (self.hash_table.io, io_value),
             (self.hash_table.length, F::from(row.length as u64)),
         ]


### PR DESCRIPTION
since it is part of the overall input recovery data