### PR TITLE
[fix] `BasicDynLookupConfig` needs selector on advice table to prevent lookup poison

### DIFF
--- a/halo2-base/src/utils/halo2.rs
+++ b/halo2-base/src/utils/halo2.rs
@@ -3,6 +3,8 @@ use crate::halo2_proofs::{
     circuit::{AssignedCell, Cell, Region, Value},
     plonk::{Advice, Assigned, Column, Fixed},
 };
+use crate::virtual_region::copy_constraints::{CopyConstraintManager, SharedCopyConstraintManager};
+use crate::AssignedValue;
 
 /// Raw (physical) assigned cell in Plonkish arithmetization.
 #[cfg(feature = "halo2-axiom")]
@@ -70,4 +72,44 @@ pub fn raw_constrain_equal<F: Field>(region: &mut Region<F>, left: Cell, right: 
     region.constrain_equal(left, right);
     #[cfg(not(feature = "halo2-axiom"))]
     region.constrain_equal(left, right).unwrap();
+}
+
+/// Assign virtual cell to raw halo2 cell in column `column` at row offset `offset` within the `region`.
+/// Stores the mapping between `virtual_cell` and the raw assigned cell in `copy_manager`, if provided.
+///
+/// `copy_manager` **must** be provided unless you are only doing witness generation
+/// without constraints.
+pub fn assign_virtual_to_raw<'v, F: Field + Ord>(
+    region: &mut Region<F>,
+    column: Column<Advice>,
+    offset: usize,
+    virtual_cell: AssignedValue<F>,
+    copy_manager: Option<&SharedCopyConstraintManager<F>>,
+) -> Halo2AssignedCell<'v, F> {
+    let raw = raw_assign_advice(region, column, offset, Value::known(virtual_cell.value));
+    if let Some(copy_manager) = copy_manager {
+        let mut copy_manager = copy_manager.lock().unwrap();
+        let cell = virtual_cell.cell.unwrap();
+        copy_manager.assigned_advices.insert(cell, raw.cell());
+        drop(copy_manager);
+    }
+    raw
+}
+
+/// Constrains that `virtual` is equal to `external`. The `virtual` cell must have
+/// **already** been raw assigned, with the raw assigned cell stored in `copy_manager`.
+///
+/// This should only be called when `witness_gen_only` is false, otherwise it will panic.
+///
+/// ## Panics
+/// If witness generation only mode is true.
+pub fn constrain_virtual_equals_external<F: Field + Ord>(
+    region: &mut Region<F>,
+    virtual_cell: AssignedValue<F>,
+    external_cell: Cell,
+    copy_manager: &CopyConstraintManager<F>,
+) {
+    let ctx_cell = virtual_cell.cell.unwrap();
+    let acell = copy_manager.assigned_advices.get(&ctx_cell).expect("cell not assigned");
+    region.constrain_equal(*acell, external_cell);
 }

--- a/halo2-base/src/virtual_region/copy_constraints.rs
+++ b/halo2-base/src/virtual_region/copy_constraints.rs
@@ -104,22 +104,6 @@ impl<F: Field + Ord> CopyConstraintManager<F> {
         self.external_cell_count = 0;
         self.assigned.take();
     }
-
-    /// Constrains that `virtual` is equal to `external`. The `virtual` cell must have
-    /// already been raw assigned. This should only be called when `witness_gen_only` is false, otherwise it will panic.
-    ///
-    /// ## Panics
-    /// If witness generation only mode is true.
-    pub fn constrain_virtual_equals_external(
-        &mut self,
-        region: &mut Region<F>,
-        virtual_cell: AssignedValue<F>,
-        external_cell: Cell,
-    ) {
-        let ctx_cell = virtual_cell.cell.unwrap();
-        let acell = self.assigned_advices.get(&ctx_cell).expect("cell not assigned");
-        region.constrain_equal(*acell, external_cell);
-    }
 }
 
 impl<F: Field + Ord> Drop for CopyConstraintManager<F> {

--- a/halo2-base/src/virtual_region/copy_constraints.rs
+++ b/halo2-base/src/virtual_region/copy_constraints.rs
@@ -104,6 +104,22 @@ impl<F: Field + Ord> CopyConstraintManager<F> {
         self.external_cell_count = 0;
         self.assigned.take();
     }
+
+    /// Constrains that `virtual` is equal to `external`. The `virtual` cell must have
+    /// already been raw assigned. This should only be called when `witness_gen_only` is false, otherwise it will panic.
+    ///
+    /// ## Panics
+    /// If witness generation only mode is true.
+    pub fn constrain_virtual_equals_external(
+        &mut self,
+        region: &mut Region<F>,
+        virtual_cell: AssignedValue<F>,
+        external_cell: Cell,
+    ) {
+        let ctx_cell = virtual_cell.cell.unwrap();
+        let acell = self.assigned_advices.get(&ctx_cell).expect("cell not assigned");
+        region.constrain_equal(*acell, external_cell);
+    }
 }
 
 impl<F: Field + Ord> Drop for CopyConstraintManager<F> {

--- a/halo2-base/src/virtual_region/lookups/basic.rs
+++ b/halo2-base/src/virtual_region/lookups/basic.rs
@@ -1,3 +1,5 @@
+use std::iter::zip;
+
 use crate::{
     halo2_proofs::{
         circuit::{Layouter, Region, Value},
@@ -9,10 +11,7 @@ use crate::{
         halo2::{raw_assign_advice, raw_assign_fixed, Halo2AssignedCell},
         ScalarField,
     },
-    virtual_region::{
-        copy_constraints::SharedCopyConstraintManager, lookups::LookupAnyManager,
-        manager::VirtualRegionManager,
-    },
+    virtual_region::copy_constraints::SharedCopyConstraintManager,
     AssignedValue,
 };
 
@@ -27,19 +26,24 @@ use crate::{
 ///
 /// The `table` consists of advice columns. Since this table may have poisoned rows (blinding factors),
 /// we use a fixed column `table_selector` which is default 0 and only 1 on enabled rows of the table.
-/// The dynamic lookup will check that a `key` in `to_lookup` matches one of the rows in `table` if
-/// that row is enabled, or `[F::ZERO; KEY_COL]` if the row is not enabled.
-/// **Therefore `[F::ZERO, KEY_COL]` should never be used as a valid key in `to_lookup`**. This must
-/// be checked on a per-implementation basis.
+/// The dynamic lookup will check that for `(key, key_is_enabled)` in `to_lookup` we have `key` matches one of
+/// the rows in `table` where `table_selector == key_is_enabled`.
+/// Reminder: the Halo2 lookup argument will ignore the poisoned rows in `to_lookup`
+/// (see [https://zcash.github.io/halo2/design/proving-system/lookup.html#zero-knowledge-adjustment]), but it will
+/// not ignore the poisoned rows in `table`.
+///
+/// Part of this design consideration is to allow a key of `[F::ZERO; KEY_COL]` to still be used as a valid key
+/// in the lookup argument. By default, unfilled rows in `to_lookup` will be all zeros; we require
+/// at least one row in `table` where `table_is_enabled = 0` and the rest of the row in `table` are also 0s.
 #[derive(Clone, Debug)]
 pub struct BasicDynLookupConfig<const KEY_COL: usize> {
-    /// Columns for cells to be looked up.
-    pub to_lookup: Vec<[Column<Advice>; KEY_COL]>,
+    /// Columns for cells to be looked up. Consists of `(key, key_is_enabled)`.
+    pub to_lookup: Vec<([Column<Advice>; KEY_COL], Column<Fixed>)>,
     /// Table to look up against.
     pub table: [Column<Advice>; KEY_COL],
     /// Selector to enable a row in `table` to actually be part of the lookup table. This is to prevent
     /// blinding factors in `table` advice columns from being used in the lookup.
-    pub table_selector: Column<Fixed>,
+    pub table_is_enabled: Column<Fixed>,
 }
 
 impl<const KEY_COL: usize> BasicDynLookupConfig<KEY_COL> {
@@ -52,50 +56,95 @@ impl<const KEY_COL: usize> BasicDynLookupConfig<KEY_COL> {
         num_lu_sets: usize,
     ) -> Self {
         let mut make_columns = || {
-            [(); KEY_COL].map(|_| {
+            let advices = [(); KEY_COL].map(|_| {
                 let advice = meta.advice_column_in(phase());
                 meta.enable_equality(advice);
                 advice
-            })
+            });
+            let is_enabled = meta.fixed_column();
+            (advices, is_enabled)
         };
-        let table = make_columns();
+        let (table, table_is_enabled) = make_columns();
         let to_lookup: Vec<_> = (0..num_lu_sets).map(|_| make_columns()).collect();
-        let table_selector = meta.fixed_column();
 
-        for to_lookup in &to_lookup {
+        for (key, key_is_enabled) in &to_lookup {
             meta.lookup_any("dynamic lookup table", |meta| {
-                let table_selector = meta.query_fixed(table_selector, Rotation::cur());
                 let table = table.map(|c| meta.query_advice(c, Rotation::cur()));
-                let to_lu = to_lookup.map(|c| meta.query_advice(c, Rotation::cur()));
-                to_lu
-                    .into_iter()
-                    .zip(table)
-                    .map(|(to_lu, table)| (to_lu, table_selector.clone() * table))
-                    .collect()
+                let table_is_enabled = meta.query_fixed(table_is_enabled, Rotation::cur());
+                let key = key.map(|c| meta.query_advice(c, Rotation::cur()));
+                let key_is_enabled = meta.query_fixed(*key_is_enabled, Rotation::cur());
+                zip(key, table).chain([(key_is_enabled, table_is_enabled)]).collect()
             });
         }
 
-        Self { table_selector, table, to_lookup }
+        Self { table_is_enabled, table, to_lookup }
     }
 
     /// Assign managed lookups
-    pub fn assign_managed_lookups<F: ScalarField>(
+    ///
+    /// `copy_manager` **must** be provided unless you are only doing witness generation
+    /// without constraints.
+    pub fn assign_virtual_to_lookup_to_raw<F: ScalarField>(
         &self,
         mut layouter: impl Layouter<F>,
-        lookup_manager: &LookupAnyManager<F, KEY_COL>,
+        keys: impl IntoIterator<Item = [AssignedValue<F>; KEY_COL]>,
+        copy_manager: Option<&SharedCopyConstraintManager<F>>,
     ) {
+        #[cfg(not(feature = "halo2-axiom"))]
+        let keys = keys.into_iter().collect::<Vec<_>>();
         layouter
             .assign_region(
-                || "Managed lookup advice",
+                || "[BasicDynLookupConfig] Advice cells to lookup",
                 |mut region| {
-                    lookup_manager.assign_raw(&self.to_lookup, &mut region);
+                    self.assign_virtual_to_lookup_to_raw_from_offset(
+                        &mut region,
+                        keys,
+                        0,
+                        copy_manager,
+                    );
                     Ok(())
                 },
             )
             .unwrap();
     }
 
-    /// Assign virtual table to raw
+    /// `copy_manager` **must** be provided unless you are only doing witness generation
+    /// without constraints.
+    pub fn assign_virtual_to_lookup_to_raw_from_offset<F: ScalarField>(
+        &self,
+        region: &mut Region<F>,
+        keys: impl IntoIterator<Item = [AssignedValue<F>; KEY_COL]>,
+        mut offset: usize,
+        copy_manager: Option<&SharedCopyConstraintManager<F>>,
+    ) {
+        let mut copy_manager = copy_manager.map(|c| c.lock().unwrap());
+        // Copied from `LookupAnyManager::assign_raw` but modified to set `key_is_enabled` to 1.
+        // Copy the cells to the config columns, going left to right, then top to bottom.
+        // Will panic if out of rows
+        let mut lookup_col = 0;
+        for key in keys {
+            if lookup_col >= self.to_lookup.len() {
+                lookup_col = 0;
+                offset += 1;
+            }
+            let (key_col, key_is_enabled_col) = self.to_lookup[lookup_col];
+            // set key_is_enabled to 1
+            raw_assign_fixed(region, key_is_enabled_col, offset, F::ONE);
+            for (advice, column) in zip(key, key_col) {
+                let bcell = raw_assign_advice(region, column, offset, Value::known(advice.value));
+                if let Some(copy_manager) = copy_manager.as_mut() {
+                    copy_manager.constrain_virtual_equals_external(region, advice, bcell.cell());
+                }
+            }
+
+            lookup_col += 1;
+        }
+    }
+
+    /// Assign virtual table to raw.
+    ///
+    /// `copy_manager` **must** be provided unless you are only doing witness generation
+    /// without constraints.
     pub fn assign_virtual_table_to_raw<F: ScalarField>(
         &self,
         mut layouter: impl Layouter<F>,
@@ -106,7 +155,7 @@ impl<const KEY_COL: usize> BasicDynLookupConfig<KEY_COL> {
         let rows = rows.into_iter().collect::<Vec<_>>();
         layouter
             .assign_region(
-                || "Dynamic Lookup Table",
+                || "[BasicDynLookupConfig] Dynamic Lookup Table",
                 |mut region| {
                     self.assign_virtual_table_to_raw_from_offset(
                         &mut region,
@@ -129,16 +178,21 @@ impl<const KEY_COL: usize> BasicDynLookupConfig<KEY_COL> {
         &self,
         region: &mut Region<F>,
         rows: impl IntoIterator<Item = [AssignedValue<F>; KEY_COL]>,
-        offset: usize,
+        mut offset: usize,
         copy_manager: Option<&SharedCopyConstraintManager<F>>,
     ) {
-        for (i, row) in rows.into_iter().enumerate() {
-            let row_offset = offset + i;
+        for row in rows {
             // Enable this row in the table
-            raw_assign_fixed(region, self.table_selector, row_offset, F::ONE);
+            raw_assign_fixed(region, self.table_is_enabled, offset, F::ONE);
             for (col, virtual_cell) in self.table.into_iter().zip(row) {
-                assign_virtual_to_raw(region, col, row_offset, virtual_cell, copy_manager);
+                assign_virtual_to_raw(region, col, offset, virtual_cell, copy_manager);
             }
+            offset += 1;
+        }
+        // always assign one disabled row with all 0s, so disabled to_lookup works for sure
+        raw_assign_fixed(region, self.table_is_enabled, offset, F::ZERO);
+        for col in self.table {
+            raw_assign_advice(region, col, offset, Value::known(F::ZERO));
         }
     }
 }

--- a/halo2-base/src/virtual_region/tests/lookups/memory.rs
+++ b/halo2-base/src/virtual_region/tests/lookups/memory.rs
@@ -1,11 +1,17 @@
-use crate::halo2_proofs::{
-    arithmetic::Field,
-    circuit::{Layouter, SimpleFloorPlanner, Value},
-    dev::MockProver,
-    halo2curves::bn256::Fr,
-    plonk::{keygen_pk, keygen_vk, Advice, Circuit, Column, ConstraintSystem, Error},
-    poly::Rotation,
+use std::any::TypeId;
+
+use crate::{
+    halo2_proofs::{
+        arithmetic::Field,
+        circuit::{Layouter, SimpleFloorPlanner},
+        dev::MockProver,
+        halo2curves::bn256::Fr,
+        plonk::{keygen_pk, keygen_vk, Assigned, Circuit, ConstraintSystem, Error},
+    },
+    virtual_region::lookups::basic::BasicDynLookupConfig,
+    AssignedValue, ContextCell,
 };
+use halo2_proofs_axiom::plonk::FirstPhase;
 use rand::{rngs::StdRng, Rng, SeedableRng};
 use test_log::test;
 
@@ -16,7 +22,6 @@ use crate::{
     },
     utils::{
         fs::gen_srs,
-        halo2::raw_assign_advice,
         testing::{check_proof, gen_proof},
         ScalarField,
     },
@@ -26,15 +31,13 @@ use crate::{
 #[derive(Clone, Debug)]
 struct RAMConfig<F: ScalarField> {
     cpu: FlexGateConfig<F>,
-    copy: Vec<[Column<Advice>; 2]>,
-    // dynamic lookup table
-    memory: [Column<Advice>; 2],
+    memory: BasicDynLookupConfig<2>,
 }
 
 #[derive(Clone, Default)]
 struct RAMConfigParams {
     cpu: FlexGateConfigParams,
-    copy_columns: usize,
+    num_lu_sets: usize,
 }
 
 struct RAMCircuit<F: ScalarField, const CYCLES: usize> {
@@ -89,30 +92,12 @@ impl<F: ScalarField, const CYCLES: usize> Circuit<F> for RAMCircuit<F, CYCLES> {
     }
 
     fn configure_with_params(meta: &mut ConstraintSystem<F>, params: Self::Params) -> Self::Config {
-        let k = params.cpu.k;
-        let mut cpu = FlexGateConfig::configure(meta, params.cpu);
-        let copy: Vec<_> = (0..params.copy_columns)
-            .map(|_| {
-                [(); 2].map(|_| {
-                    let advice = meta.advice_column();
-                    meta.enable_equality(advice);
-                    advice
-                })
-            })
-            .collect();
-        let mem = [meta.advice_column(), meta.advice_column()];
+        let memory = BasicDynLookupConfig::new(meta, || FirstPhase, params.num_lu_sets);
+        let cpu = FlexGateConfig::configure(meta, params.cpu);
 
-        for copy in &copy {
-            meta.lookup_any("dynamic memory lookup table", |meta| {
-                let mem = mem.map(|c| meta.query_advice(c, Rotation::cur()));
-                let copy = copy.map(|c| meta.query_advice(c, Rotation::cur()));
-                vec![(copy[0].clone(), mem[0].clone()), (copy[1].clone(), mem[1].clone())]
-            });
-        }
         log::info!("Poisoned rows: {}", meta.minimum_rows());
-        cpu.max_rows = (1 << k) - meta.minimum_rows();
 
-        RAMConfig { cpu, copy, memory: mem }
+        RAMConfig { cpu, memory }
     }
 
     fn configure(_: &mut ConstraintSystem<F>) -> Self::Config {
@@ -124,21 +109,41 @@ impl<F: ScalarField, const CYCLES: usize> Circuit<F> for RAMCircuit<F, CYCLES> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
+        // Make purely virtual cells so we can raw assign them
+        let memory = self.memory.iter().enumerate().map(|(i, value)| {
+            let idx = Assigned::Trivial(F::from(i as u64 + 1));
+            let idx = AssignedValue {
+                value: idx,
+                cell: Some(ContextCell::new(TypeId::of::<RAMConfig<F>>(), 0, i)),
+            };
+            let value = Assigned::Trivial(*value);
+            let value = AssignedValue {
+                value,
+                cell: Some(ContextCell::new(TypeId::of::<RAMConfig<F>>(), 1, i)),
+            };
+            [idx, value]
+        });
+        config.memory.assign_virtual_table_to_raw(
+            layouter.namespace(|| "memory"),
+            memory,
+            (!self.cpu.witness_gen_only()).then_some(&self.cpu.copy_manager),
+        );
+
         layouter.assign_region(
-            || "RAM Circuit",
+            || "cpu",
             |mut region| {
-                // Raw assign the private memory inputs
-                for (i, &value) in self.memory.iter().enumerate() {
-                    // I think there will always be (0, 0) in the table so we index starting from 1
-                    let idx = Value::known(F::from(i as u64 + 1));
-                    raw_assign_advice(&mut region, config.memory[0], i, idx);
-                    raw_assign_advice(&mut region, config.memory[1], i, Value::known(value));
-                }
                 self.cpu.assign_raw(
                     &(config.cpu.basic_gates[0].clone(), config.cpu.max_rows),
                     &mut region,
                 );
-                self.ram.assign_raw(&config.copy, &mut region);
+                Ok(())
+            },
+        )?;
+        config.memory.assign_managed_lookups(layouter.namespace(|| "memory accesses"), &self.ram);
+        // copy constraints at the very end for safety:
+        layouter.assign_region(
+            || "copy constraints",
+            |mut region| {
                 self.cpu.copy_manager.assign_raw(&config.cpu.constants, &mut region);
                 Ok(())
             },
@@ -155,7 +160,6 @@ fn test_ram_mock() {
     let memory: Vec<_> = (0..mem_len).map(|_| Fr::random(&mut rng)).collect();
     let ptrs = [(); CYCLES].map(|_| rng.gen_range(0..memory.len()));
     let usable_rows = 2usize.pow(k) - 11; // guess
-    let copy_columns = CYCLES / usable_rows + 1;
     let params = RAMConfigParams::default();
     let mut circuit = RAMCircuit::new(memory, ptrs, params, false);
     circuit.compute();
@@ -166,7 +170,7 @@ fn test_ram_mock() {
         num_advice_per_phase: vec![num_advice],
         num_fixed: 1,
     };
-    circuit.params.copy_columns = copy_columns;
+    circuit.params.num_lu_sets = CYCLES / usable_rows + 1;
     MockProver::run(k, &circuit, vec![]).unwrap().assert_satisfied();
 }
 
@@ -182,7 +186,6 @@ fn test_ram_prover() {
     let ptrs = [0; CYCLES];
 
     let usable_rows = 2usize.pow(k) - 11; // guess
-    let copy_columns = CYCLES / usable_rows + 1;
     let params = RAMConfigParams::default();
     let mut circuit = RAMCircuit::new(memory, ptrs, params, false);
     circuit.compute();
@@ -192,7 +195,7 @@ fn test_ram_prover() {
         num_advice_per_phase: vec![num_advice],
         num_fixed: 1,
     };
-    circuit.params.copy_columns = copy_columns;
+    circuit.params.num_lu_sets = CYCLES / usable_rows + 1;
 
     let params = gen_srs(k);
     let vk = keygen_vk(&params, &circuit).unwrap();


### PR DESCRIPTION
This fixes a soundness bug described in https://github.com/privacy-scaling-explorations/zkevm-circuits/issues/866 

Previously `BasicDynLookupConfig` allowed the `table` to be pure advice columns. As the above issue describes, this should essentially never be allowed, because each advice column has poisoned rows that the prover could put whatever they want in. This means the prover could put erroneous information in the poisoned rows to allow certain lookups to pass even when it does not contain the intended information in the `table`.

We fix this by adding a fixed column `table_is_enabled` to `BasicDynLookupConfig` and also a fixed column `key_is_enabled` for each set of `KEY_COLS` advice columns to be looked up. The`table_is_enabled` value in the fixed column defaults to 0, and we set it to 1 only when we raw assign a virtual table. We also only set `key_is_enabled = 1` on rows where we want to do a dynamic lookup. The dynamic lookup argument is then to check that `key_is_enabled = table_is_enabled` _and then_ to match the `key` to a `table` row. To ensure that the unused `to_lookup` rows pass, we always make sure the `table` has a row of all zeros.

The reason we use a fixed column for both `to_lookup` and `table` is because we do have use cases where we want to make sure `[0; KEY_COLS]` is **not** a valid lookup. This was hard to do without two separate selectors.

I have changed the `memory` example test to use `BasicDynLookupConfig` to test the happy path and also to test the case that when a `[0; KEY_COLS]` is not in the enabled table, the lookup will fail.