### PR TITLE
[chore] fix dev graph tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run clippy
-        run: cargo clippy --all -- -D warnings
+        run: cargo clippy --all --all-targets -- -D warnings
 
       - name: Generate Cargo.lock
         run: cargo generate-lockfile

--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -27,7 +27,6 @@ halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.gi
 poseidon-rs = { git = "https://github.com/axiom-crypto/poseidon-circuit.git", rev = "1aee4a1" }
 # plotting circuit layout
 plotters = { version = "0.3.0", optional = true }
-tabbycat = { version = "0.1", features = ["attributes"], optional = true }
 
 # test-utils
 rand = { version = "0.8", optional = true }
@@ -54,11 +53,7 @@ mimalloc = { version = "0.1", default-features = false, optional = true }
 [features]
 default = ["halo2-axiom", "display", "test-utils"]
 asm = ["halo2_proofs_axiom?/asm"]
-dev-graph = [
-    "halo2_proofs?/dev-graph",
-    "halo2_proofs_axiom?/dev-graph",
-    "plotters",
-]
+dev-graph = ["halo2_proofs/dev-graph", "plotters"] # only works with halo2-pse for now
 halo2-pse = ["halo2_proofs/circuit-params"]
 halo2-axiom = ["halo2_proofs_axiom"]
 display = []

--- a/halo2-base/src/gates/tests/general.rs
+++ b/halo2-base/src/gates/tests/general.rs
@@ -52,28 +52,26 @@ fn test_multithread_gates() {
     );
 }
 
-/*
 #[cfg(feature = "dev-graph")]
 #[test]
 fn plot_gates() {
     let k = 5;
     use plotters::prelude::*;
 
+    use crate::gates::circuit::builder::BaseCircuitBuilder;
+
     let root = BitMapBackend::new("layout.png", (1024, 1024)).into_drawing_area();
     root.fill(&WHITE).unwrap();
     let root = root.titled("Gates Layout", ("sans-serif", 60)).unwrap();
 
     let inputs = [Fr::zero(); 3];
-    let builder = GateThreadBuilder::new(false);
+    let mut builder = BaseCircuitBuilder::new(false).use_k(k);
     gate_tests(builder.main(0), inputs);
 
     // auto-tune circuit
-    builder.config(k, Some(9));
-    // create circuit
-    let circuit = RangeCircuitBuilder::keygen(builder);
-    halo2_proofs::dev::CircuitLayout::default().render(k, &circuit, &root).unwrap();
+    builder.calculate_params(Some(9));
+    halo2_proofs::dev::CircuitLayout::default().render(k as u32, &builder, &root).unwrap();
 }
-*/
 
 fn range_tests<F: BigPrimeField>(
     ctx: &mut Context<F>,

--- a/halo2-ecc/Cargo.toml
+++ b/halo2-ecc/Cargo.toml
@@ -8,9 +8,7 @@ itertools = "0.10"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-integer = "0.1"
 num-traits = "0.2"
-rand_core = { version = "0.6", default-features = false, features = [
-    "getrandom",
-] }
+rand_core = { version = "0.6", default-features = false, features = ["getrandom"] }
 rand = "0.8"
 rand_chacha = "0.3.1"
 serde = { version = "1.0", features = ["derive"] }
@@ -20,20 +18,21 @@ test-case = "3.1.0"
 
 halo2-base = { path = "../halo2-base", default-features = false }
 
+# plotting circuit layout
+plotters = { version = "0.3.0", optional = true }
+
 [dev-dependencies]
 ark-std = { version = "0.3.0", features = ["print-trace"] }
 pprof = { version = "0.13", features = ["criterion", "flamegraph"] }
 criterion = "0.5.1"
 criterion-macro = "0.4"
-halo2-base = { path = "../halo2-base", default-features = false, features = [
-    "test-utils",
-] }
+halo2-base = { path = "../halo2-base", default-features = false, features = ["test-utils"] }
 test-log = "0.2.12"
 env_logger = "0.10.0"
 
 [features]
 default = ["jemallocator", "halo2-axiom", "display"]
-dev-graph = ["halo2-base/dev-graph"]
+dev-graph = ["halo2-base/dev-graph", "plotters"]
 display = ["halo2-base/display"]
 asm = ["halo2-base/asm"]
 halo2-pse = ["halo2-base/halo2-pse"]


### PR DESCRIPTION
Only works for `halo2-pse` because the feature is currently disabled for `halo2-axiom`.

Test using
```
cargo t plot_gates --no-default-features --features "halo2-pse, dev-graph"

cargo t plot_fp --no-default-features --features "halo2-pse, dev-graph"
```