### PR TITLE
fix: `TypeId` in `ContextTag` not stable across builds

### DIFF
--- a/halo2-base/README.md
+++ b/halo2-base/README.md
@@ -69,6 +69,8 @@ During `synthesize()`, the advice values of all `Context`s are concatenated into
 
 For parallel witness generation, multiple `Context`s are created for each parallel operation. After parallel witness generation, these `Context`'s are combined to form a single "virtual column" as above. Note that while the witness generation can be multi-threaded, the ordering of the contents in each `Context`, and the order of the `Context`s themselves, must be deterministic.
 
+**Warning:** If you create your own `Context` in a new virtual region not provided by our libraries, you must ensure that the `type_id: &str` of the context is a globally unique identifier for the virtual region, distinct from the other `type_id` strings used to identify other virtual regions. In the future we will introduce a macro to check this uniqueness at compile time.
+
 ### [**AssignedValue**](./src/lib.rs):
 
 Despite the name, an `AssignedValue` is a **virtual cell**. It contains the actual witness value as well as a pointer to the location of the virtual cell within a virtual region. The pointer is given by type `ContextCell`. We only store the pointer when not in witness generation only mode as an optimization.

--- a/halo2-base/src/gates/flex_gate/threads/single_phase.rs
+++ b/halo2-base/src/gates/flex_gate/threads/single_phase.rs
@@ -1,4 +1,4 @@
-use std::{any::TypeId, cell::RefCell};
+use std::cell::RefCell;
 
 use getset::CopyGetters;
 
@@ -13,10 +13,7 @@ use crate::{
     Context, ContextCell,
 };
 use crate::{
-    halo2_proofs::{
-        circuit::{Region, Value},
-        plonk::{FirstPhase, SecondPhase, ThirdPhase},
-    },
+    halo2_proofs::circuit::{Region, Value},
     virtual_region::manager::VirtualRegionManager,
 };
 
@@ -114,11 +111,11 @@ impl<F: ScalarField> SinglePhaseCoreManager<F> {
     }
 
     /// A distinct tag for this particular type of virtual manager, which is different for each phase.
-    pub fn type_of(&self) -> TypeId {
+    pub fn type_of(&self) -> &'static str {
         match self.phase {
-            0 => TypeId::of::<(Self, FirstPhase)>(),
-            1 => TypeId::of::<(Self, SecondPhase)>(),
-            2 => TypeId::of::<(Self, ThirdPhase)>(),
+            0 => "SinglePhaseCoreManager: FirstPhase",
+            1 => "SinglePhaseCoreManager: SecondPhase",
+            2 => "SinglePhaseCoreManager: ThirdPhase",
             _ => panic!("Unsupported phase"),
         }
     }

--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -119,7 +119,7 @@ pub struct ContextCell {
 }
 
 impl ContextCell {
-    /// Creates a new [ContextCell] with the given `type_name`, `context_id`, and `offset`.
+    /// Creates a new [ContextCell] with the given `type_id`, `context_id`, and `offset`.
     pub fn new(type_id: &'static str, context_id: usize, offset: usize) -> Self {
         Self { type_id, context_id, offset }
     }

--- a/halo2-base/src/virtual_region/copy_constraints.rs
+++ b/halo2-base/src/virtual_region/copy_constraints.rs
@@ -1,4 +1,3 @@
-use std::any::TypeId;
 use std::collections::{BTreeMap, HashMap};
 use std::ops::DerefMut;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -87,7 +86,7 @@ impl<F: Field + Ord> CopyConstraintManager<F> {
     }
 
     fn load_external_cell_impl(&mut self, cell: Option<Cell>) -> ContextCell {
-        let context_cell = ContextCell::new(TypeId::of::<Cell>(), 0, self.external_cell_count);
+        let context_cell = ContextCell::new("External Raw Halo2 Cell", 0, self.external_cell_count);
         self.external_cell_count += 1;
         if let Some(cell) = cell {
             self.assigned_advices.insert(context_cell, cell);


### PR DESCRIPTION
We were using `TypeId` inside `ContextTag`, inside of `ContextCell` as a unique identifier for the virtual region the `ContextCell` belonged to. 

However, we were using the ordering of the different `TypeId`s to order the contexts, which in particular affects the order that `cells_to_lookup` is assigned to the Plonkish matrix: 
https://github.com/axiom-crypto/halo2-lib/blob/67e3a0eee37c3b25b393cdea7514fef4e8af0bf9/halo2-base/src/virtual_region/lookups.rs#L44C36-L44C36
(we order by converting `BTreeMap` to iterator).

Rust creates the values for `TypeId` in some way that varies across builds, and even when dependencies or features enabled changes. This means that the circuits created were sound, but the proving & verifying key generated for a circuit would change depending on what features (e.g., `asm`) were enabled, or they might change if some downstream dependency changed versions. This is very brittle.

After considering the options, we opted for the same solution as https://github.com/filecoin-project/ec-gpu/pull/30#discussion_r936854168 where we just use `&str` to tag the virtual region. We can currently only impose the soft requirement that developers must ensure the strings used to describe different virtual regions must be globally unique across the virtual regions used in a particular circuit.

In the future we plan to add some kind of macro to check this uniqueness at compile time.