### PR TITLE
[feat] add `bits_to_num` and `limbs_to_num`

### DIFF
--- a/halo2-base/src/gates/flex_gate/mod.rs
+++ b/halo2-base/src/gates/flex_gate/mod.rs
@@ -1280,7 +1280,7 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
     /// Assumes values of `bits` are boolean.
     /// * `bits`: slice of [QuantumCell]'s that contains bit representation in little-endian form
     fn bits_to_num(&self, ctx: &mut Context<F>, bits: &[AssignedValue<F>]) -> AssignedValue<F> {
-        assert!((bits.len() as u32) < F::CAPACITY);
+        assert!((bits.len() as u32) <= F::CAPACITY);
 
         self.inner_product(
             ctx,

--- a/halo2-base/src/gates/flex_gate/mod.rs
+++ b/halo2-base/src/gates/flex_gate/mod.rs
@@ -863,6 +863,12 @@ pub trait GateInstructions<F: ScalarField> {
         range_bits: usize,
     ) -> Vec<AssignedValue<F>>;
 
+    /// Constrains and returns field representation of little-endian bit vector `bits`.
+    ///
+    /// Assumes values of `bits` are boolean.
+    /// * `bits`: slice of [QuantumCell]'s that contains bit representation in little-endian form
+    fn bits_to_num(&self, ctx: &mut Context<F>, bits: &[AssignedValue<F>]) -> AssignedValue<F>;
+
     /// Constrains and computes `a`<sup>`exp`</sup> where both `a, exp` are witnesses. The exponent is computed in the native field `F`.
     ///
     /// Constrains that `exp` has at most `max_bits` bits.
@@ -1267,6 +1273,20 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
             self.assert_bit(ctx, *bit_cell);
         }
         bit_cells
+    }
+
+    /// Constrains and returns field representation of little-endian bit vector `bits`.
+    ///
+    /// Assumes values of `bits` are boolean.
+    /// * `bits`: slice of [QuantumCell]'s that contains bit representation in little-endian form
+    fn bits_to_num(&self, ctx: &mut Context<F>, bits: &[AssignedValue<F>]) -> AssignedValue<F> {
+        assert!((bits.len() as u32) < F::CAPACITY);
+
+        self.inner_product(
+            ctx,
+            bits.iter().map(|x| *x),
+            self.pow_of_two[..bits.len()].iter().map(|c| Constant(*c)),
+        )
     }
 
     /// Constrains and computes `a^exp` where both `a, exp` are witnesses. The exponent is computed in the native field `F`.

--- a/halo2-base/src/gates/flex_gate/mod.rs
+++ b/halo2-base/src/gates/flex_gate/mod.rs
@@ -1284,7 +1284,7 @@ impl<F: ScalarField> GateInstructions<F> for GateChip<F> {
 
         self.inner_product(
             ctx,
-            bits.iter().map(|x| *x),
+            bits.iter().copied(),
             self.pow_of_two[..bits.len()].iter().map(|c| Constant(*c)),
         )
     }

--- a/halo2-base/src/gates/range/mod.rs
+++ b/halo2-base/src/gates/range/mod.rs
@@ -471,7 +471,7 @@ pub trait RangeInstructions<F: ScalarField> {
     {
         self.gate().inner_product(
             ctx,
-            limbs.iter().map(|x| *x),
+            limbs.iter().copied(),
             self.gate()
                 .pow_of_two()
                 .iter()

--- a/halo2-base/src/gates/tests/flex_gate.rs
+++ b/halo2-base/src/gates/tests/flex_gate.rs
@@ -214,6 +214,14 @@ pub fn test_num_to_bits(num: usize, bits: usize) -> Vec<Fr> {
     })
 }
 
+#[test_case([0,1,1].map(Fr::from).to_vec() => Fr::from(6); "bits_to_num(): [0,1,1]")]
+pub fn test_bits_to_num(bits: Vec<Fr>) -> Fr {
+    base_test().run_gate(|ctx, chip| {
+        let bits = ctx.assign_witnesses(bits);
+        *chip.bits_to_num(ctx, bits.as_slice()).value()
+    })
+}
+
 #[test_case(Fr::from(3), BigUint::from(3u32), 4 => Fr::from(27); "pow_var(): 3^3 = 27")]
 pub fn test_pow_var(a: Fr, exp: BigUint, max_bits: usize) -> Fr {
     assert!(exp.bits() <= max_bits as u64);

--- a/halo2-base/src/gates/tests/range.rs
+++ b/halo2-base/src/gates/tests/range.rs
@@ -114,3 +114,11 @@ pub fn test_decompose_le(num: Fr, limb_bits: usize, num_limbs: usize) -> Vec<Fr>
         chip.decompose_le(ctx, num, limb_bits, num_limbs).iter().map(|x| *x.value()).collect()
     })
 }
+
+#[test_case([0x4, 0x3, 0x2, 0x1].map(Fr::from).to_vec(), 4 => Fr::from(0x1234); "limbs_to_num([0x4, 0x3, 0x2, 0x1], 4)")]
+pub fn test_limbs_to_num(limbs: Vec<Fr>, limb_bits: usize) -> Fr {
+    base_test().run(|ctx, chip| {
+        let limbs = ctx.assign_witnesses(limbs);
+        *chip.limbs_to_num(ctx, limbs.as_slice(), limb_bits).value()
+    })
+}


### PR DESCRIPTION
Adds a couple of functions to reconstruct field elements from their bit/limb representations
- `bits_to_num` to `GateInstructions`
- `limbs_to_num` to `RangeInstructions`

Assumes the bit/limb representation is valid and doesn't range check the bits/limbs.

One thing to note is that there can be multiple bit/limb representations that map to the same field element. For eg. with 254 bits and working on BN254, both the bit representations of `x` and `x + p` (254 bits) will map to `x`. It might make sense to range check the input to be less than `p` in such a case