### PR TITLE
[feat] Trait for Circuit with Default Inputs

### DIFF
--- a/halo2-base/src/utils/halo2.rs
+++ b/halo2-base/src/utils/halo2.rs
@@ -1,3 +1,5 @@
+use halo2_proofs_axiom::plonk::Circuit;
+
 use crate::ff::Field;
 use crate::halo2_proofs::{
     circuit::{AssignedCell, Cell, Region, Value},
@@ -112,4 +114,10 @@ pub fn constrain_virtual_equals_external<F: Field + Ord>(
     let ctx_cell = virtual_cell.cell.unwrap();
     let acell = copy_manager.assigned_advices.get(&ctx_cell).expect("cell not assigned");
     region.constrain_equal(*acell, external_cell);
+}
+
+/// Circuit with default values.
+pub trait CircuitWithDefault<F: Field>: Circuit<F> {
+    /// Return Circuit with default inputs for the given params.
+    fn default(witness_gen_only: bool, params: Self::Params) -> Self;
 }

--- a/halo2-base/src/utils/halo2.rs
+++ b/halo2-base/src/utils/halo2.rs
@@ -118,6 +118,6 @@ pub fn constrain_virtual_equals_external<F: Field + Ord>(
 
 /// Circuit with default values.
 pub trait CircuitWithDefault<F: Field>: Circuit<F> {
-    /// Return Circuit with default inputs for the given params.
-    fn default(witness_gen_only: bool, params: Self::Params) -> Self;
+    /// Return Circuit with default inputs for the given params. Return struct could be used for pkey generation.
+    fn default(params: Self::Params) -> Self;
 }

--- a/halo2-base/src/virtual_region/tests/lookups/memory.rs
+++ b/halo2-base/src/virtual_region/tests/lookups/memory.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use crate::{
     halo2_proofs::{
         arithmetic::Field,


### PR DESCRIPTION
- Add  `CircuitWithDefault` trait which can return a circuit instance with default inputs for given params.