### PR TITLE
[fix] soundness bug in `BasicDynLookupConfig::assign_virtual_table_to_raw`

### DIFF
--- a/halo2-base/src/gates/flex_gate/threads/single_phase.rs
+++ b/halo2-base/src/gates/flex_gate/threads/single_phase.rs
@@ -219,9 +219,15 @@ pub fn assign_with_constraints<F: ScalarField, const ROTATIONS: usize>(
                 .assign_advice(|| "", column, row_offset, || value.map(|v| *v))
                 .unwrap()
                 .cell();
-            copy_manager
+            if let Some(old_cell) = copy_manager
                 .assigned_advices
-                .insert(ContextCell::new(ctx.type_id, ctx.context_id, i), cell);
+                .insert(ContextCell::new(ctx.type_id, ctx.context_id, i), cell)
+            {
+                assert!(
+                    old_cell.row_offset == cell.row_offset && old_cell.column == cell.column,
+                    "Trying to overwrite virtual cell with a different raw cell"
+                );
+            }
 
             // If selector enabled and row_offset is valid add break point, account for break point overlap, and enforce equality constraint for gate outputs.
             // ⚠️ This assumes overlap is of form: gate enabled at `i - delta` and `i`, where `delta = ROTATIONS - 1`. We currently do not support `delta < ROTATIONS - 1`.

--- a/halo2-base/src/utils/halo2.rs
+++ b/halo2-base/src/utils/halo2.rs
@@ -1,9 +1,11 @@
+use std::collections::hash_map::Entry;
+
 use crate::ff::Field;
 use crate::halo2_proofs::{
     circuit::{AssignedCell, Cell, Region, Value},
     plonk::{Advice, Assigned, Column, Fixed},
 };
-use crate::virtual_region::copy_constraints::{CopyConstraintManager, SharedCopyConstraintManager};
+use crate::virtual_region::copy_constraints::{CopyConstraintManager, EXTERNAL_CELL_TYPE_ID};
 use crate::AssignedValue;
 
 /// Raw (physical) assigned cell in Plonkish arithmetization.
@@ -74,30 +76,11 @@ pub fn raw_constrain_equal<F: Field>(region: &mut Region<F>, left: Cell, right: 
     region.constrain_equal(left, right).unwrap();
 }
 
-/// Assign virtual cell to raw halo2 cell in column `column` at row offset `offset` within the `region`.
-/// Stores the mapping between `virtual_cell` and the raw assigned cell in `copy_manager`, if provided.
-///
-/// `copy_manager` **must** be provided unless you are only doing witness generation
-/// without constraints.
-pub fn assign_virtual_to_raw<'v, F: Field + Ord>(
-    region: &mut Region<F>,
-    column: Column<Advice>,
-    offset: usize,
-    virtual_cell: AssignedValue<F>,
-    copy_manager: Option<&SharedCopyConstraintManager<F>>,
-) -> Halo2AssignedCell<'v, F> {
-    let raw = raw_assign_advice(region, column, offset, Value::known(virtual_cell.value));
-    if let Some(copy_manager) = copy_manager {
-        let mut copy_manager = copy_manager.lock().unwrap();
-        let cell = virtual_cell.cell.unwrap();
-        copy_manager.assigned_advices.insert(cell, raw.cell());
-        drop(copy_manager);
-    }
-    raw
-}
-
-/// Constrains that `virtual` is equal to `external`. The `virtual` cell must have
-/// **already** been raw assigned, with the raw assigned cell stored in `copy_manager`.
+/// Constrains that `virtual_cell` is equal to `external_cell`. The `virtual_cell` must have
+/// already been raw assigned with the raw assigned cell stored in `copy_manager`
+/// **unless** it is marked an external-only cell with type id [EXTERNAL_CELL_TYPE_ID].
+/// * When the virtual cell has already been assigned, the assigned cell is constrained to be equal to the external cell.
+/// * When the virtual cell has not been assigned **and** it is marked as an external cell, it is assigned to `external_cell` and the mapping is stored in `copy_manager`.
 ///
 /// This should only be called when `witness_gen_only` is false, otherwise it will panic.
 ///
@@ -107,9 +90,19 @@ pub fn constrain_virtual_equals_external<F: Field + Ord>(
     region: &mut Region<F>,
     virtual_cell: AssignedValue<F>,
     external_cell: Cell,
-    copy_manager: &CopyConstraintManager<F>,
+    copy_manager: &mut CopyConstraintManager<F>,
 ) {
     let ctx_cell = virtual_cell.cell.unwrap();
-    let acell = copy_manager.assigned_advices.get(&ctx_cell).expect("cell not assigned");
-    region.constrain_equal(*acell, external_cell);
+    match copy_manager.assigned_advices.entry(ctx_cell) {
+        Entry::Occupied(acell) => {
+            // The virtual cell has already been assigned, so we can constrain it to equal the external cell.
+            region.constrain_equal(*acell.get(), external_cell);
+        }
+        Entry::Vacant(assigned) => {
+            // The virtual cell **must** be an external cell
+            assert_eq!(ctx_cell.type_id, EXTERNAL_CELL_TYPE_ID);
+            // We map the virtual cell to point to the raw external cell in `copy_manager`
+            assigned.insert(external_cell);
+        }
+    }
 }

--- a/halo2-base/src/virtual_region/copy_constraints.rs
+++ b/halo2-base/src/virtual_region/copy_constraints.rs
@@ -92,7 +92,12 @@ impl<F: Field + Ord> CopyConstraintManager<F> {
         let context_cell = ContextCell::new(EXTERNAL_CELL_TYPE_ID, 0, self.external_cell_count);
         self.external_cell_count += 1;
         if let Some(cell) = cell {
-            self.assigned_advices.insert(context_cell, cell);
+            if let Some(old_cell) = self.assigned_advices.insert(context_cell, cell) {
+                assert!(
+                    old_cell.row_offset == cell.row_offset && old_cell.column == cell.column,
+                    "External cell already assigned"
+                )
+            }
         }
         context_cell
     }

--- a/halo2-base/src/virtual_region/copy_constraints.rs
+++ b/halo2-base/src/virtual_region/copy_constraints.rs
@@ -15,6 +15,9 @@ use crate::{ff::Field, ContextCell};
 
 use super::manager::VirtualRegionManager;
 
+/// Type ID to distinguish external raw Halo2 cells. **This Type ID must be unique.**
+pub const EXTERNAL_CELL_TYPE_ID: &str = "halo2-base:External Raw Halo2 Cell";
+
 /// Thread-safe shared global manager for all copy constraints.
 pub type SharedCopyConstraintManager<F> = Arc<Mutex<CopyConstraintManager<F>>>;
 
@@ -86,8 +89,7 @@ impl<F: Field + Ord> CopyConstraintManager<F> {
     }
 
     fn load_external_cell_impl(&mut self, cell: Option<Cell>) -> ContextCell {
-        let context_cell =
-            ContextCell::new("halo2-base:External Raw Halo2 Cell", 0, self.external_cell_count);
+        let context_cell = ContextCell::new(EXTERNAL_CELL_TYPE_ID, 0, self.external_cell_count);
         self.external_cell_count += 1;
         if let Some(cell) = cell {
             self.assigned_advices.insert(context_cell, cell);

--- a/halo2-base/src/virtual_region/lookups.rs
+++ b/halo2-base/src/virtual_region/lookups.rs
@@ -125,7 +125,8 @@ impl<F: Field + Ord, const ADVICE_COLS: usize> VirtualRegionManager<F>
     type Config = Vec<[Column<Advice>; ADVICE_COLS]>;
 
     fn assign_raw(&self, config: &Self::Config, region: &mut Region<F>) {
-        let copy_manager = (!self.witness_gen_only).then(|| self.copy_manager().lock().unwrap());
+        let mut copy_manager =
+            (!self.witness_gen_only).then(|| self.copy_manager().lock().unwrap());
         let cells_to_lookup = self.cells_to_lookup.lock().unwrap();
         // Copy the cells to the config columns, going left to right, then top to bottom.
         // Will panic if out of rows
@@ -139,7 +140,7 @@ impl<F: Field + Ord, const ADVICE_COLS: usize> VirtualRegionManager<F>
             for (advice, &column) in advices.iter().zip(config[lookup_col].iter()) {
                 let bcell =
                     raw_assign_advice(region, column, lookup_offset, Value::known(advice.value));
-                if let Some(copy_manager) = copy_manager.as_ref() {
+                if let Some(copy_manager) = copy_manager.as_mut() {
                     constrain_virtual_equals_external(region, *advice, bcell.cell(), copy_manager);
                 }
             }

--- a/halo2-base/src/virtual_region/tests/lookups/memory.rs
+++ b/halo2-base/src/virtual_region/tests/lookups/memory.rs
@@ -1,5 +1,3 @@
-use std::any::TypeId;
-
 use crate::{
     halo2_proofs::{
         arithmetic::Field,
@@ -8,7 +6,9 @@ use crate::{
         halo2curves::bn256::Fr,
         plonk::{keygen_pk, keygen_vk, Assigned, Circuit, ConstraintSystem, Error},
     },
-    virtual_region::lookups::basic::BasicDynLookupConfig,
+    virtual_region::{
+        copy_constraints::EXTERNAL_CELL_TYPE_ID, lookups::basic::BasicDynLookupConfig,
+    },
     AssignedValue, ContextCell,
 };
 use halo2_proofs_axiom::plonk::FirstPhase;
@@ -109,24 +109,6 @@ impl<F: ScalarField, const CYCLES: usize> Circuit<F> for RAMCircuit<F, CYCLES> {
         config: Self::Config,
         mut layouter: impl Layouter<F>,
     ) -> Result<(), Error> {
-        // Make purely virtual cells so we can raw assign them
-        let memory = self.memory.iter().enumerate().map(|(i, value)| {
-            let idx = Assigned::Trivial(F::from(i as u64));
-            let idx =
-                AssignedValue { value: idx, cell: Some(ContextCell::new("RAM Config", 0, i)) };
-            let value = Assigned::Trivial(*value);
-            let value = AssignedValue { value, cell: Some(ContextCell::new("RAM Config", 1, i)) };
-            [idx, value]
-        });
-
-        let copy_manager = (!self.cpu.witness_gen_only()).then_some(&self.cpu.copy_manager);
-
-        config.memory.assign_virtual_table_to_raw(
-            layouter.namespace(|| "memory"),
-            memory,
-            copy_manager,
-        );
-
         layouter.assign_region(
             || "cpu",
             |mut region| {
@@ -137,6 +119,28 @@ impl<F: ScalarField, const CYCLES: usize> Circuit<F> for RAMCircuit<F, CYCLES> {
                 Ok(())
             },
         )?;
+
+        let copy_manager = (!self.cpu.witness_gen_only()).then_some(&self.cpu.copy_manager);
+
+        // Make purely virtual cells so we can raw assign them
+        let memory = self.memory.iter().enumerate().map(|(i, value)| {
+            let idx = Assigned::Trivial(F::from(i as u64));
+            let idx = AssignedValue {
+                value: idx,
+                cell: Some(ContextCell::new(EXTERNAL_CELL_TYPE_ID, 0, i)),
+            };
+            let value = Assigned::Trivial(*value);
+            let value =
+                AssignedValue { value, cell: Some(ContextCell::new(EXTERNAL_CELL_TYPE_ID, 1, i)) };
+            [idx, value]
+        });
+
+        config.memory.assign_virtual_table_to_raw(
+            layouter.namespace(|| "memory"),
+            memory,
+            copy_manager,
+        );
+
         config.memory.assign_virtual_to_lookup_to_raw(
             layouter.namespace(|| "memory accesses"),
             self.mem_access.clone(),


### PR DESCRIPTION
The problem is that in `assign_virtual_table_to_raw` it was using `assign_virtual_to_raw`, which has the following danger:
* It will "assign" a virtual cell to a raw Halo2 cell by inserting the assignment into the `HashMap` of `assigned_advices`. However later the `BaseCircuitBuilder` `raw_assign` might overwrite this assignment **without** adding any real equality constraints. Therefore the first raw cell becomes a dangling unconstrained cell.

The fix is that now `assign_virtual_table_to_raw` uses `constrain_virtual_equals_external`, and we have modified `constrain_virtual_equals_external` so that it checks whether the virtual cell has already been assigned or not. It is **only** allowed to not have been assigned if the `type_id` of the virtual cell was marked as `EXTERNAL_CELL_TYPE_ID`. This marks the virtual cell as safe from ever being reassigned by a different virtual region manager.
* If the virtual cell is already assigned to a raw cell, we constrain equality between the raw cell and the new external cell.
* If the virtual cell has not been assigned and is marked `EXTERNAL_CELL_TYPE_ID`, then we assign the virtual cell to the new external cell.

The usage in the latter case is demonstrated in the `memory.rs` test.

We add a check whenever we do `assigned_advice.insert` that there was not already a cell present **or** that the occupied raw cell equals the raw cell to be inserted (this latter case is just because `keygen_vk` and `keygen_pk` each call `synthesize` and we cannot call `clear` because of mutable borrows).