### PR TITLE
fix:multipiler->multipiler

### DIFF
--- a/hashes/zkevm/src/keccak/component/encode.rs
+++ b/hashes/zkevm/src/keccak/component/encode.rs
@@ -82,8 +82,8 @@ pub fn pack_native_input<F: Field>(bytes: &[u8]) -> Vec<Vec<F>> {
             chunk
                 .chunks(num_word_per_witness)
                 .map(|c| {
-                    c.iter().zip(multipliers.iter()).fold(F::ZERO, |acc, (word, multipiler)| {
-                        acc + F::from_u128(*word) * multipiler
+                    c.iter().zip(multipliers.iter()).fold(F::ZERO, |acc, (word, multiplier)| {
+                        acc + F::from_u128(*word) * multiplier
                     })
                 })
                 .collect_vec()


### PR DESCRIPTION
in this context, I think use  **multipiler** is more consistent