### PR TITLE
chore: fix keccak capacity check

### DIFF
--- a/hashes/zkevm/src/keccak/component/circuit/shard.rs
+++ b/hashes/zkevm/src/keccak/component/circuit/shard.rs
@@ -232,7 +232,7 @@ impl<F: Field> KeccakComponentShardCircuit<F> {
         witness_gen_only: bool,
     ) -> Self {
         let input_size = inputs.iter().map(|input| get_num_keccak_f(input.len())).sum::<usize>();
-        assert!(input_size < params.capacity, "Input size exceeds capacity");
+        assert!(input_size <= params.capacity, "Input size exceeds capacity");
         let mut base_circuit_builder = BaseCircuitBuilder::new(witness_gen_only);
         base_circuit_builder.set_params(params.base_circuit_params.clone());
         Self {


### PR DESCRIPTION
Used capacity is allowed to be `= params.capacity`