### PR TITLE
chore(zkevm-hashes): use git tag for snark-verifier-sdk

### DIFF
--- a/hashes/zkevm/Cargo.toml
+++ b/hashes/zkevm/Cargo.toml
@@ -23,7 +23,7 @@ rayon = "1.8"
 sha3 = "0.10.8"
 # always included but without features to use Native poseidon and get CircuitExt trait
 # snark-verifier-sdk = { version = "=0.1.7", default-features = false }
-snark-verifier-sdk = { git = "https://github.com/axiom-crypto/snark-verifier.git", branch = "main", default-features = false }
+snark-verifier-sdk = { version = "=0.1.7", git = "https://github.com/axiom-crypto/snark-verifier.git", tag = "v0.1.7-git", default-features = false }
 getset = "0.1.2"
 type-map = "0.5.0"
 


### PR DESCRIPTION
There is an unfortunate circular dependency where snark-verifier depends on a tag of halo2-base but then zkevm-hashes needs a tag of snark-verifier.

I will re-tag `v0.4.1-git` after merging this.