### PR TITLE
fix: update toolchain to nightly to fix failing bench builds

### DIFF
--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2023-08-12
+nightly

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2024-02-19


### PR DESCRIPTION
running benches:
```bash
cargo test --release -- --nocapture bench_msm
```

is currently failing to build:
```bash
error: package `clap_builder v4.5.0` cannot be built because it requires rustc 1.74 or newer, while the currently active rustc version is 1.73.0-nightly
Either upgrade to rustc 1.74 or newer, or use
cargo update -p clap_builder@4.5.0 --precise ver
where `ver` is the latest version of `clap_builder` supporting rustc 1.73.0-nightly
```
PR simply updates to nightly in rust-toolchain