### PR TITLE
Grammar and Clarity Improvements

### DIFF
--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -516,7 +516,7 @@ where
     let zero_cell = ctx.load_zero();
     rounded_bits.resize(rounded_bitlen, zero_cell);
 
-    // is_started[idx] holds whether there is a 1 in bits with index at least (rounded_bitlen - idx)
+    // is_started[idx] holds whether there is a 1 in bits with an index at least (rounded_bitlen - idx)
     let mut is_started = Vec::with_capacity(rounded_bitlen);
     is_started.resize(rounded_bitlen - total_bits + 1, zero_cell);
     for idx in 1..=total_bits {
@@ -755,7 +755,7 @@ where
                 &rounded_bits
                     [rounded_bitlen - window_bits * (idx + 1)..rounded_bitlen - window_bits * idx],
             );
-            // this all needs strict add_unequal since A can be non-randomly chosen by adversary
+            // this all needs strict add_unequal since A can be non-randomly chosen by an adversary
             curr_point = ec_add_unequal(chip, ctx, curr_point, add_point, true);
         }
     }

--- a/hashes/zkevm/src/sha256/README.md
+++ b/hashes/zkevm/src/sha256/README.md
@@ -39,9 +39,9 @@ such that the bits in the message are: <original message of length L> 1 <K zeros
   - `length`: the running length in bytes of input data "absorbed" so far, including the current block, excluding padding. This is only constrained when `q_input` is true. One recovers the length of the unpadded input by reading this value on the last "absorb" row in a block with `is_enabled` true.
   - `word_value`: 32 bits of the input, as described above. We use the following slightly funny conversion: we consider the 4 byte chunk of the input, replace the padding with 0s, and then convert to a 32-bit integer by considering the 4 bytes _in little endian_. This choice was chosen for consistency with the Keccak circuit, but is arbitrary.
     - Only constrained when `q_input` is true.
-  - `output` (2): the hash digest the SHA-256 algorithm on the input bytes (32 bytes). We represent this as two field elements in hi-lo form - we split 32 bytes into two 16 byte chunks, and convert them to `u128` as _big endian_.
+  - `output` (2): the hash digest of the SHA-256 algorithm on the input bytes (32 bytes). We represent this as two field elements in hi-lo form - we split 32 bytes into two 16 byte chunks, and convert them to `u128` as _big endian_.
     - Only constrained when the last row of a block. Should only be considered meaningful when `is_enabled` is true.
-- We convenient store the relevant cells for the above data, per input block, in the struct `AssignedSha256Block`.
+- We conveniently store the relevant cells for the above data, per input block, in the struct `AssignedSha256Block`.
 - This circuit has a hard constraint that the input array has length up to `2^32 - 1` bits, whereas the official SHA-256 spec supports up to `2^64 - 1`. (In practice it is likely impossible to create a circuit that can handle `2^32 - 1` bit inputs.)
 - Details are provided in inline comments.
 


### PR DESCRIPTION

## Changes

### File: halo2-ecc/src/ecc/mod.rs

1. Added missing article "an":
// Old:
// is_started[idx] holds whether there is a 1 in bits with index at least (rounded_bitlen - idx)
// New: 
// is_started[idx] holds whether there is a 1 in bits with an index at least (rounded_bitlen - idx)

2. Added missing article "an":
// Old:
// this all needs strict add_unequal since A can be non-randomly chosen by adversary
// New:
// this all needs strict add_unequal since A can be non-randomly chosen by an adversary

### File: hashes/zkevm/src/sha256/README.md

1. Added missing "of":
// Old:
- `output` (2): the hash digest the SHA-256 algorithm on the input bytes
// New:
- `output` (2): the hash digest of the SHA-256 algorithm on the input bytes

2. Fixed adverb form:
// Old:
- We convenient store the relevant cells
// New:
- We conveniently store the relevant cells
