### PR TITLE
Fix typos

### DIFF
--- a/hashes/zkevm/src/keccak/component/output.rs
+++ b/hashes/zkevm/src/keccak/component/output.rs
@@ -32,7 +32,7 @@ pub fn multi_inputs_to_circuit_outputs<F: Field>(
     outputs
 }
 
-/// Return corresponding circuit outputs of a native input in bytes. An logical input could produce multiple
+/// Return corresponding circuit outputs of a native input in bytes. A logical input could produce multiple
 /// outputs. The last one is the lookup key and hash of the input. Other outputs are paddings which are the lookup
 /// key and hash of an empty input.
 pub fn input_to_circuit_outputs<F: Field>(bytes: &[u8]) -> Vec<KeccakCircuitOutput<F>> {

--- a/hashes/zkevm/src/keccak/vanilla/keccak_packed_multi.rs
+++ b/hashes/zkevm/src/keccak/vanilla/keccak_packed_multi.rs
@@ -141,7 +141,7 @@ pub struct KeccakTable {
     pub output: Word<Column<Advice>>,
     /// Raw keccak words(NUM_BYTES_PER_WORD bytes) of inputs
     pub word_value: Column<Advice>,
-    /// Number of bytes left of a input
+    /// Number of bytes left of an input
     pub bytes_left: Column<Advice>,
 }
 


### PR DESCRIPTION
This pull request addresses minor typographical issues in the `keccak` module of the project, improving the clarity and correctness of comments.

### Summary of Changes:
1. **Fixed grammatical errors**:
   - In `output.rs`:
     - Corrected "An logical input" to "A logical input."
   - In `keccak_packed_multi.rs`:
     - Corrected "a input" to "an input."

2. **Files Modified**:
   - `hashes/zkevm/src/keccak/component/output.rs`
   - `hashes/zkevm/src/keccak/vanilla/keccak_packed_multi.rs`
