### PR TITLE
fix: update broken links docs README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ cd halo2-lib
 
 ## halo2-base
 
-This crate provides an additional API for writing circuits in Halo 2 using our [simple vertical gate](https://docs.axiom.xyz/zero-knowledge-proofs/getting-started-with-halo2#halo2-lib). It also provides basic functions built using this API. The provided methods can be found in [`GateInstructions`](https://axiom-crypto.github.io/halo2-lib/halo2_base/gates/trait.GateInstructions.html) and [`RangeInstructions`](https://axiom-crypto.github.io/halo2-lib/halo2_base/gates/trait.RangeInstructions.html). The latter are operations that require using a lookup table for range checks.
+This crate provides an additional API for writing circuits in Halo 2 using our [simple vertical gate](https://docs.axiom.xyz/zero-knowledge-proofs/getting-started-with-halo2#halo2-lib). It also provides basic functions built using this API. The provided methods can be found in [`GateInstructions`](https://axiom-crypto.github.io/halo2-lib/halo2_base/gates/flex_gate/trait.GateInstructions.html) and [`RangeInstructions`](https://axiom-crypto.github.io/halo2-lib/halo2_base/gates/range/trait.RangeInstructions.html). The latter are operations that require using a lookup table for range checks.
 
 - Read the [Rust docs](https://docs.rs/halo2-base/0.4.1/halo2_base/) for this crate.
 - To get started with Halo 2 and to learn how to build using the `halo2-base` API, see the [Getting Started](https://docs.axiom.xyz/zero-knowledge-proofs/getting-started-with-halo2) guide.


### PR DESCRIPTION
Hi! I noticed that some of the links in the `README.md` file were broken, so I updated them to point to the correct resources. Now all links should lead to the appropriate pages, improving navigation and documentation usability.  
