### PR TITLE
docs: fix typos and update broken link in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ cd halo2-lib
 - [indexed-merkle-tree](https://github.com/aerius-labs/indexed-merkle-tree-halo2) -- Indexed Merkle Tree operations in halo2.
 - [zkCert](https://github.com/zkCert/halo2-zkcert) -- Verify a chain of x509 certificates in halo2.
 - [zk-dcap-verifier](https://github.com/CliqueOfficial/zk-dcap-verifier) -- On-chain DCAP attestation verification.
-- [polymon_gan](https://github.com/Modulus-Labs/polymon_gan) -- Prover for the Polymon GAN network.
 - [MynaWallet](https://github.com/MynaWallet/monorepo/tree/develop/packages/halo2-circuits) -- Verifies RSA signatures signed by Myna Card (Japan's ID Card).
 - [zk-face-circuit](https://github.com/team-byof/zk-face-circuit) -- Face Wallet Verification system for Ethereum wallets.
 - [halo2-lib-secp256r1](https://github.com/CliqueOfficial/halo2-lib-secp256r1)

--- a/docs/src/halo2_base/gates/builder.rs.html
+++ b/docs/src/halo2_base/gates/builder.rs.html
@@ -848,7 +848,7 @@
 <span class="kw">impl</span>&lt;F: ScalarField&gt; GateThreadBuilder&lt;F&gt; {
     <span class="doccomment">/// Creates a new [GateThreadBuilder] and spawns a main thread in phase 0.
     /// * `witness_gen_only`: If true, the [GateThreadBuilder] is used for witness generation only.
-    ///     * If true, the gate thread builder only does witness asignments and does not store constraint information -- this should only be used for the real prover.
+    ///     * If true, the gate thread builder only does witness assignments and does not store constraint information -- this should only be used for the real prover.
     ///     * If false, the gate thread builder is used for keygen and mock prover (it can also be used for real prover) and the builder stores circuit information (e.g. copy constraints, fixed columns, enabled selectors).
     ///         * These values are fixed for the circuit at key generation time, and they do not need to be re-computed by the prover in the actual proving phase.
     </span><span class="kw">pub fn </span>new(witness_gen_only: bool) -&gt; <span class="self">Self </span>{
@@ -928,7 +928,7 @@
 
     <span class="doccomment">/// Auto-calculates configuration parameters for the circuit
     ///
-    /// * `k`: The number of in the circuit (i.e. numeber of rows = 2&lt;sup&gt;k&lt;/sup&gt;)
+    /// * `k`: The number of in the circuit (i.e. number of rows = 2&lt;sup&gt;k&lt;/sup&gt;)
     /// * `minimum_rows`: The minimum number of rows in the circuit that cannot be used for witness assignments and contain random `blinding factors` to ensure zk property, defaults to 0.
     </span><span class="kw">pub fn </span>config(<span class="kw-2">&amp;</span><span class="self">self</span>, k: usize, minimum_rows: <span class="prelude-ty">Option</span>&lt;usize&gt;) -&gt; FlexGateConfigParams {
         <span class="kw">let </span>max_rows = (<span class="number">1 </span>&lt;&lt; k) - minimum_rows.unwrap_or(<span class="number">0</span>);

--- a/docs/src/halo2_base/safe_types/mod.rs.html
+++ b/docs/src/halo2_base/safe_types/mod.rs.html
@@ -163,12 +163,12 @@
 <span class="kw">const </span>BITS_PER_BYTE: usize = <span class="number">8</span>;
 
 <span class="doccomment">/// SafeType&#39;s goal is to avoid out-of-range undefined behavior.
-/// When building circuits, it&#39;s common to use mulitple AssignedValue&lt;F&gt; to represent
-/// a logical varaible. For example, we might want to represent a hash with 32 AssignedValue&lt;F&gt;
+/// When building circuits, it&#39;s common to use multiple AssignedValue&lt;F&gt; to represent
+/// a logical variable. For example, we might want to represent a hash with 32 AssignedValue&lt;F&gt;
 /// where each AssignedValue represents 1 byte. However, the range of AssignedValue&lt;F&gt; is much
 /// larger than 1 byte(0~255). If a circuit takes 32 AssignedValue&lt;F&gt; as inputs and some of them
 /// are actually greater than 255, there could be some undefined behaviors.
-/// SafeType gurantees the value range of its owned AssignedValue&lt;F&gt;. So circuits don&#39;t need to
+/// SafeType guarantees the value range of its owned AssignedValue&lt;F&gt;. So circuits don&#39;t need to
 /// do any extra value checking if they take SafeType as inputs.
 /// TOTAL_BITS is the number of total bits of this type.
 /// BYTES_PER_ELE is the number of bytes of each element.

--- a/docs/src/halo2_base/utils.rs.html
+++ b/docs/src/halo2_base/utils.rs.html
@@ -567,7 +567,7 @@
     <span class="doccomment">/// Creates a field element from a little endian byte representation.
     ///
     /// The default implementation assumes that `PrimeField::from_repr` is implemented for little-endian.
-    /// It should be overriden if this is not the case.
+    /// It should be overridden if this is not the case.
     </span><span class="kw">fn </span>from_bytes_le(bytes: <span class="kw-2">&amp;</span>[u8]) -&gt; <span class="self">Self </span>{
         <span class="kw">let </span><span class="kw-2">mut </span>repr = <span class="self">Self</span>::Repr::default();
         repr.as_mut()[..bytes.len()].copy_from_slice(bytes);

--- a/halo2-ecc/src/bigint/carry_mod.rs
+++ b/halo2-ecc/src/bigint/carry_mod.rs
@@ -22,7 +22,7 @@ use super::{check_carry_to_zero, CRTInteger, OverflowInteger, ProperCrtUint, Pro
 //
 // Assumption: the leading two bits (in big endian) are 1,
 /// # Assumptions
-/// * abs(a) <= 2<sup>n * k - 1 + F::NUM_BITS - 2</sup> (A weaker assumption is also enough, but this is good enough for forseeable use cases)
+/// * abs(a) <= 2<sup>n * k - 1 + F::NUM_BITS - 2</sup> (A weaker assumption is also enough, but this is good enough for foreseeable use cases)
 /// * `native_modulus::<F>` requires *exactly* `k = a.limbs.len()` limbs to represent
 
 // This is currently optimized for limbs greater than 64 bits, so we need `F` to be a `BigPrimeField`


### PR DESCRIPTION
## Description

Hi! This pull request focuses on fixing typos and addressing a broken link in the project's documentation and code comments. These changes aim to enhance clarity and accuracy while maintaining the functionality of the codebase.

### Key Changes
- **Removed a broken link** in `README.md` related to `polymon_gan`.
- **Fixed typos** in the following files:
  - `carry_mod.rs`: Corrected "forseeable" to "foreseeable".
  - `builder.rs.html`: Addressed spelling errors in comments ("asignments" to "assignments", "numeber" to "number").
  - `mod.rs.html`: Fixed typos such as "mulitple" to "multiple" and "varaible" to "variable".
  - `utils.rs.html`: Corrected "overriden" to "overridden".