### PR TITLE
docs: fix grammatical error in feature documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ The default features are: "jemallocator", "halo2-axiom", "display".
 You can turn off "display" for a very small performance increase, where certain statistics about the circuit are not
 computed and printed.
 
-**Exactly one** of "halo2-axiom" or "halo2-pse" feature should be turned on at all times.
+**Exactly one** of "halo2-axiom" or "halo2-pse" features should be turned on at all times.
 
 - The "halo2-axiom" feature uses our [`halo2_proofs`](https://github.com/axiom-crypto/halo2) which is a fork of the [PSE one](https://github.com/privacy-scaling-explorations/halo2) which we have slightly optimized for proving speed.
 - The "halo2-pse" feature uses the Privacy Scaling Explorations [`halo2_proofs`](https://github.com/privacy-scaling-explorations/halo2) which is the most stable and has the most reviewers.


### PR DESCRIPTION
I noticed a grammatical issue in the documentation. The word "feature" should be pluralized to "features" since the sentence refers to two options ("halo2-axiom" and "halo2-pse").  

The corrected sentence:  
**"Exactly one of 'halo2-axiom' or 'halo2-pse' features should be turned on at all times."**  

This change ensures clarity and grammatical correctness.