### PR TITLE
fix: Remove unnecessary explicit memory deallocation

### DIFF
--- a/halo2-ecc/benches/fixed_base_msm.rs
+++ b/halo2-ecc/benches/fixed_base_msm.rs
@@ -92,7 +92,6 @@ fn bench(c: &mut Criterion) {
     let vk = keygen_vk(&params, &circuit).expect("vk should not fail");
     let pk = keygen_pk(&params, vk, &circuit).expect("pk should not fail");
     let break_points = circuit.break_points();
-    drop(circuit);
 
     let (bases, scalars): (Vec<_>, Vec<_>) =
         (0..config.batch_size).map(|_| (G1Affine::random(&mut rng), Fr::random(&mut rng))).unzip();


### PR DESCRIPTION
  I noticed that `drop(circuit);` is used explicitly in the code. Since Rust automatically handles memory deallocation when variables go out of scope, this line is redundant. I removed it to simplify the code without changing its behavior.
This makes the code cleaner and more idiomatic.