### PR TITLE
chore: fix some typos

### DIFF
--- a/halo2-base/src/utils/testing.rs
+++ b/halo2-base/src/utils/testing.rs
@@ -27,7 +27,7 @@ use rand::{rngs::StdRng, SeedableRng};
 
 use super::fs::gen_srs;
 
-/// Helper function to generate a proof with real prover using SHPLONK KZG multi-open polynomical commitment scheme
+/// Helper function to generate a proof with real prover using SHPLONK KZG multi-open polynomial commitment scheme
 /// and Blake2b as the hash function for Fiat-Shamir.
 pub fn gen_proof_with_instances(
     params: &ParamsKZG<Bn256>,
@@ -49,7 +49,7 @@ pub fn gen_proof_with_instances(
     transcript.finalize()
 }
 
-/// For testing use only: Helper function to generate a proof **without public instances** with real prover using SHPLONK KZG multi-open polynomical commitment scheme
+/// For testing use only: Helper function to generate a proof **without public instances** with real prover using SHPLONK KZG multi-open polynomial commitment scheme
 /// and Blake2b as the hash function for Fiat-Shamir.
 pub fn gen_proof(
     params: &ParamsKZG<Bn256>,
@@ -59,7 +59,7 @@ pub fn gen_proof(
     gen_proof_with_instances(params, pk, circuit, &[])
 }
 
-/// Helper function to verify a proof (generated using [`gen_proof_with_instances`]) using SHPLONK KZG multi-open polynomical commitment scheme
+/// Helper function to verify a proof (generated using [`gen_proof_with_instances`]) using SHPLONK KZG multi-open polynomial commitment scheme
 /// and Blake2b as the hash function for Fiat-Shamir.
 pub fn check_proof_with_instances(
     params: &ParamsKZG<Bn256>,
@@ -87,7 +87,7 @@ pub fn check_proof_with_instances(
     }
 }
 
-/// For testing only: Helper function to verify a proof (generated using [`gen_proof`]) without public instances using SHPLONK KZG multi-open polynomical commitment scheme
+/// For testing only: Helper function to verify a proof (generated using [`gen_proof`]) without public instances using SHPLONK KZG multi-open polynomial commitment scheme
 /// and Blake2b as the hash function for Fiat-Shamir.
 pub fn check_proof(
     params: &ParamsKZG<Bn256>,

--- a/hashes/zkevm/src/keccak/component/encode.rs
+++ b/hashes/zkevm/src/keccak/component/encode.rs
@@ -76,8 +76,8 @@ pub fn pack_native_input<F: Field>(bytes: &[u8]) -> Vec<Vec<F>> {
             chunk
                 .chunks(num_word_per_witness)
                 .map(|c| {
-                    c.iter().zip(multipliers.iter()).fold(F::ZERO, |acc, (word, multipiler)| {
-                        acc + F::from_u128(*word) * multipiler
+                    c.iter().zip(multipliers.iter()).fold(F::ZERO, |acc, (word, multiplier)| {
+                        acc + F::from_u128(*word) * multiplier
                     })
                 })
                 .collect_vec()

--- a/hashes/zkevm/src/util/word.rs
+++ b/hashes/zkevm/src/util/word.rs
@@ -291,7 +291,7 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
     /// it need more recursive call. if the converted limbs word will be used in many places,
     /// consider create new low limbs word, have equality constrain, then finally use low limbs
     /// elsewhere.
-    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    // TODO static assertion. workaround https://github.com/nvzqz/static-assertions-rs/issues/40
     pub fn to_word_n<const N2: usize>(&self) -> WordLimbs<Expression<F>, N2> {
         assert_eq!(N1 % N2, 0);
         let limbs = self
@@ -305,7 +305,7 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
     }
 
     /// Equality expression
-    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    // TODO static assertion. workaround https://github.com/nvzqz/static-assertions-rs/issues/40
     pub fn eq<const N2: usize>(&self, others: &WordLimbs<Expression<F>, N2>) -> Expression<F> {
         assert_eq!(N1 % N2, 0);
         not::expr(or::expr(

--- a/hashes/zkevm/src/util/word.rs
+++ b/hashes/zkevm/src/util/word.rs
@@ -291,7 +291,7 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
     /// it need more recursive call. if the converted limbs word will be used in many places,
     /// consider create new low limbs word, have equality constrain, then finally use low limbs
     /// elsewhere.
-    // TODO static assertion. workaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
     pub fn to_word_n<const N2: usize>(&self) -> WordLimbs<Expression<F>, N2> {
         assert_eq!(N1 % N2, 0);
         let limbs = self
@@ -305,7 +305,7 @@ impl<F: Field, const N1: usize> WordLimbs<Expression<F>, N1> {
     }
 
     /// Equality expression
-    // TODO static assertion. workaround https://github.com/nvzqz/static-assertions-rs/issues/40
+    // TODO static assertion. wordaround https://github.com/nvzqz/static-assertions-rs/issues/40
     pub fn eq<const N2: usize>(&self, others: &WordLimbs<Expression<F>, N2>) -> Expression<F> {
         assert_eq!(N1 % N2, 0);
         not::expr(or::expr(


### PR DESCRIPTION
## Description
This pull request fixes several typos in the codebase:

- Corrected **"polynomical"** to **"polynomial"** in documentation comments.
- Corrected **"multipiler"** to **"multiplier"** in the folding logic.
- No logic or functionality is changed; only comments and variable names are updated for clarity and correctness.

These changes improve code readability and maintain consistency across the project.