### PR TITLE
Update broken flamegraph article link to current Medium URL

### DIFF
--- a/halo2-base/benches/inner_product.rs
+++ b/halo2-base/benches/inner_product.rs
@@ -18,7 +18,7 @@ use criterion::{BenchmarkId, Criterion};
 
 use pprof::criterion::{Output, PProfProfiler};
 // Thanks to the example provided by @jebbow in his article
-// https://www.jibbow.com/posts/criterion-flamegraphs/
+// https://jibbow.medium.com/automatic-flamegraphs-for-benchmarks-with-criterion-f8e59499cc2a
 
 const K: u32 = 19;
 


### PR DESCRIPTION
Replaced the outdated and broken link to the criterion flamegraph article (previously on jibbow.com) with the current, working Medium URL by the same author. This ensures that readers can access the referenced guide for integrating flamegraphs with Criterion benchmarks. No other code changes were made.