### PR TITLE
Update ZK introduction link in README to latest official Axiom blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository aims to provide basic primitives for writing zero-knowledge proo
 
 ## Getting Started
 
-For a brief introduction to zero-knowledge proofs (ZK), see this [doc](https://docs.axiom.xyz/zero-knowledge-proofs/introduction-to-zk).
+For a brief introduction to zero-knowledge proofs (ZK), see this [blog post](https://blog.axiom.xyz/introducing-axiom/).
 
 Halo 2 is written in Rust, so you need to [install](https://www.rust-lang.org/tools/install) Rust to use this library:
 


### PR DESCRIPTION
Replaced the outdated link to the zero-knowledge proofs (ZK) introduction in the README with the current official Axiom blog post. The previous docs.axiom.xyz link is no longer available, and the blog post now serves as the recommended introduction to ZK and Axiom’s mission.