### PR TITLE
Remove unused import of Field in inner_product.rs example

### DIFF
--- a/halo2-base/examples/inner_product.rs
+++ b/halo2-base/examples/inner_product.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test-utils")]
 use halo2_base::gates::flex_gate::{GateChip, GateInstructions};
 use halo2_base::gates::RangeInstructions;
-use halo2_base::halo2_proofs::{arithmetic::Field, halo2curves::bn256::Fr};
+use halo2_base::halo2_proofs::{halo2curves::bn256::Fr};
 use halo2_base::utils::testing::base_test;
 use halo2_base::utils::ScalarField;
 use halo2_base::{Context, QuantumCell::Existing};


### PR DESCRIPTION
This commit removes the unused import of the Field trait from the halo2_proofs crate in the inner_product.rs example file. The Field trait was not referenced anywhere in the code, and its removal helps keep the imports clean and maintainable.