### PR TITLE
Fix typo in Cargo.toml comment

### DIFF
--- a/halo2-base/Cargo.toml
+++ b/halo2-base/Cargo.toml
@@ -28,7 +28,7 @@ halo2_proofs_axiom = { version = "0.4", package = "halo2-axiom", optional = true
 # Use PSE halo2 and halo2curves for compatibility when feature = "halo2-pse" is on
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v0.3.0", features = ["circuit-params", "derive_serde"], optional = true }
 
-# This is Scroll's audited poseidon circuit. We only use it for the Native Poseidon spec. We do not use the halo2 circuit at all (and it wouldn't even work because the halo2_proofs tag is not compatbile).
+# This is Scroll's audited poseidon circuit. We only use it for the Native Poseidon spec. We do not use the halo2 circuit at all (and it wouldn't even work because the halo2_proofs tag is not compatible).
 # We forked it to upgrade to ff v0.13 and removed the circuit module
 poseidon-rs = { package = "poseidon-primitives", version = "=0.1.1" }
 # plotting circuit layout


### PR DESCRIPTION
Fix spelling error in comment: "compatbile" → "compatible"

This corrects a simple typo in the dependency comment explaining 
why the halo2_proofs tag compatibility issue exists.