### PR TITLE
Improve error messages for empty coefficient vectors in field operations

### DIFF
--- a/halo2-ecc/src/fields/vector.rs
+++ b/halo2-ecc/src/fields/vector.rs
@@ -284,7 +284,7 @@ where
                 prev = Some(coeff);
             }
         }
-        prev.unwrap()
+        prev.expect("empty coefficient vector in is_soft_zero")
     }
 
     pub fn is_soft_nonzero(
@@ -302,7 +302,7 @@ where
                 prev = Some(coeff);
             }
         }
-        prev.unwrap()
+        prev.expect("empty coefficient vector in is_soft_nonzero")
     }
 
     pub fn is_zero(
@@ -320,7 +320,7 @@ where
                 prev = Some(coeff);
             }
         }
-        prev.unwrap()
+        prev.expect("empty coefficient vector in is_zero")
     }
 
     pub fn is_equal_unenforced(
@@ -338,7 +338,7 @@ where
                 acc = Some(coeff);
             }
         }
-        acc.unwrap()
+        acc.expect("empty coefficient vector in is_equal_unenforced")
     }
 
     pub fn assert_equal(


### PR DESCRIPTION

## Description

Replace `unwrap()` calls with descriptive `expect()` messages in field vector operations to provide better error diagnostics when empty coefficient vectors are encountered.

### Changes
- **`is_soft_zero`**: Added descriptive error message for empty coefficient vector
- **`is_soft_nonzero`**: Added descriptive error message for empty coefficient vector  
- **`is_zero`**: Added descriptive error message for empty coefficient vector
- **`is_equal_unenforced`**: Added descriptive error message for empty coefficient vector
