### PR TITLE
refactor: convert for loop to functional approach in inner_product_with_sums_ground_truth

### DIFF
--- a/halo2-base/src/gates/tests/utils.rs
+++ b/halo2-base/src/gates/tests/utils.rs
@@ -57,15 +57,15 @@ pub fn inner_product_with_sums_ground_truth<F: ScalarField>(
     input: &(Vec<QuantumCell<F>>, Vec<QuantumCell<F>>),
 ) -> Vec<F> {
     let (a, b) = &input;
-    let mut result = Vec::new();
     let mut sum = F::ZERO;
-    // TODO: convert to fold
-    for (ai, bi) in a.iter().zip(b) {
-        let product = *ai.value() * *bi.value();
-        sum += product;
-        result.push(sum);
-    }
-    result
+    a.iter()
+        .zip(b)
+        .map(|(ai, bi)| {
+            let product = *ai.value() * *bi.value();
+            sum += product;
+            sum
+        })
+        .collect()
 }
 
 pub fn sum_products_with_coeff_and_var_ground_truth<F: ScalarField>(


### PR DESCRIPTION
Replace imperative for loop with functional map/collect approach in inner_product_with_sums_ground_truth function to address TODO comment.

This change makes the code more functional and follows Rust best practices while preserving the original logic for computing cumulative sums of products.