### PR TITLE
Use OS-backed CSPRNG in testing helper to avoid deterministic RNG

### DIFF
--- a/halo2-base/src/utils/testing.rs
+++ b/halo2-base/src/utils/testing.rs
@@ -23,7 +23,7 @@ use crate::{
     Context,
 };
 use ark_std::{end_timer, perf_trace::TimerInfo, start_timer};
-use rand::{rngs::StdRng, SeedableRng};
+use rand::rngs::OsRng;
 
 use super::fs::gen_srs;
 
@@ -35,7 +35,8 @@ pub fn gen_proof_with_instances(
     circuit: impl Circuit<Fr>,
     instances: &[&[Fr]],
 ) -> Vec<u8> {
-    let rng = StdRng::seed_from_u64(0);
+    // Use OS-backed CSPRNG to avoid deterministic RNG in a public testing helper
+    let rng = OsRng;
     let mut transcript = Blake2bWrite::<_, _, Challenge255<_>>::init(vec![]);
     create_proof::<
         KZGCommitmentScheme<Bn256>,


### PR DESCRIPTION


### Description
- **What**: Replace `StdRng::seed_from_u64(0)` with `OsRng` in `halo2-base/src/utils/testing.rs`. Updated `rand` imports and added a brief comment.
- **Why**: Deterministic RNG in a publicly accessible testing helper is risky for cryptographic code if reused inadvertently. OS-backed CSPRNG ensures non-predictable randomness.
- **Impact**: No API changes. Proofs may differ across runs. If deterministic behavior is needed in tests, consider passing a seeded RNG explicitly or gating test-only helpers behind a feature/`cfg(test)`.
- **Security**: Reduces the chance of predictable randomness being used in proof generation.
- **Alternatives considered**:
  - Accept an RNG parameter (`impl RngCore + CryptoRng`) in `gen_proof_with_instances`.
 