### PR TITLE
Remove unused commented import in lib.rs

### DIFF
--- a/halo2-base/src/lib.rs
+++ b/halo2-base/src/lib.rs
@@ -32,7 +32,6 @@ compile_error!(
 #[cfg(not(any(feature = "halo2-pse", feature = "halo2-axiom")))]
 compile_error!("Must enable exactly one of \"halo2-pse\" or \"halo2-axiom\" features to choose which halo2_proofs crate to use.");
 
-// use gates::flex_gate::MAX_PHASE;
 #[cfg(feature = "halo2-pse")]
 pub use halo2_proofs;
 #[cfg(feature = "halo2-axiom")]


### PR DESCRIPTION

## Summary
Remove unused commented import `// use gates::flex_gate::MAX_PHASE;` from `halo2-base/src/lib.rs`.

## Changes
- Deleted line 35: `// use gates::flex_gate::MAX_PHASE;`

## Rationale
- The constant `MAX_PHASE` is actively used throughout the codebase (35 occurrences found)
- It's imported directly in modules where needed, not through the main library file

