### PR TITLE
Optimize FieldVector conversion to avoid unnecessary container cloning

### DIFF
--- a/halo2-ecc/src/fields/vector.rs
+++ b/halo2-ecc/src/fields/vector.rs
@@ -40,7 +40,7 @@ impl<T> AsRef<[T]> for FieldVector<T> {
 
 impl<'a, T: Clone, U: From<T>> From<&'a FieldVector<T>> for FieldVector<U> {
     fn from(other: &'a FieldVector<T>) -> Self {
-        FieldVector(other.clone().into_iter().map(Into::into).collect())
+        FieldVector(other.0.iter().cloned().map(Into::into).collect())
     }
 }
 


### PR DESCRIPTION

## Summary
Replace full container cloning with element-wise iteration in `FieldVector<T>` to `FieldVector<U>` conversion.

## Problem
The `From<&'a FieldVector<T>> for FieldVector<U>` implementation was performing unnecessary full container cloning:
```rust
FieldVector(other.clone().into_iter().map(Into::into).collect())
```

This creates an intermediate `Vec<T>` allocation before converting elements, causing:
- Unnecessary memory allocation and copying
- Temporary memory pressure (doubling memory usage)
- Performance degradation on large vectors

## Solution
Replace with direct iteration over references with element cloning:
```rust
FieldVector(other.0.iter().cloned().map(Into::into).collect())
```

