### PR TITLE
fix: correct extra-limb assertion in get_naf

### DIFF
--- a/halo2-ecc/src/ecc/mod.rs
+++ b/halo2-ecc/src/ecc/mod.rs
@@ -799,7 +799,7 @@ pub fn get_naf(mut exp: Vec<u64>) -> Vec<i8> {
         }
     }
     if exp.len() != len {
-        assert_eq!(len, exp.len() + 1);
+        assert_eq!(exp.len(), len + 1);
         assert!(exp[len] == 1);
         naf.push(1);
     }

--- a/halo2-ecc/src/ecc/tests.rs
+++ b/halo2-ecc/src/ecc/tests.rs
@@ -13,7 +13,7 @@ use halo2_base::utils::bigint_to_fe;
 use halo2_base::utils::testing::base_test;
 use halo2_base::utils::value_to_option;
 use halo2_base::SKIP_FIRST_PASS;
-use num_bigint::{BigInt, RandBigInt};
+use num_bigint::{BigInt, BigUint, RandBigInt};
 use rand_core::OsRng;
 use std::marker::PhantomData;
 use std::ops::Neg;
@@ -65,4 +65,31 @@ fn test_ecc() {
         let Q = G1Affine::random(OsRng);
         basic_g1_tests(ctx, range, 22, 88, 3, P, Q);
     });
+}
+
+#[test]
+fn test_get_naf_roundtrip() {
+    fn roundtrip(exp: BigUint) {
+        let limbs: Vec<u64> = exp.iter_u64_digits().collect();
+        let naf = get_naf(limbs);
+
+        let mut value = BigInt::from(0u64);
+        let mut pow2 = BigInt::from(1u64);
+        for z in naf {
+            match z {
+                -1 => value -= &pow2,
+                0 => {}
+                1 => value += &pow2,
+                _ => panic!("unexpected NAF digit"),
+            }
+            pow2 <<= 1;
+        }
+
+        let reconstructed = value.to_biguint().expect("NAF representation should be non-negative");
+        assert_eq!(reconstructed, exp);
+    }
+
+    roundtrip(BigUint::from(1u64));
+    roundtrip((BigUint::from(u64::MAX) << 64) + BigUint::from(u64::MAX));
+    roundtrip((BigUint::from(1u64) << 127) + BigUint::from(123456789u64));
 }


### PR DESCRIPTION
get_naf may grow the exponent vector by one limb when a carry propagates past the most significant limb. In that case we expect exp.len() == len + 1, but the final assertion compared the lengths in the wrong order and would always panic if this branch was ever hit. This change fixes the assertion to check exp.len() == len + 1 and keeps the invariant that the newly added limb is exactly 1, so the extra carry is handled correctly instead of causing a spurious panic.