### PR TITLE
chore: bump license year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Axiom
+Copyright (c) 2026 Axiom
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary
Updated copyright year in LICENSE file(s).

**Before:** 2025
**After:** 2026

Routine maintenance to keep copyright notices up to date.