### PR TITLE
fix: record actual bench phase durations instead of TimerInfo start instants

### DIFF
--- a/halo2-base/src/utils/testing.rs
+++ b/halo2-base/src/utils/testing.rs
@@ -22,8 +22,9 @@ use crate::{
     },
     Context,
 };
-use ark_std::{end_timer, perf_trace::TimerInfo, start_timer};
+use ark_std::{end_timer, start_timer};
 use rand::{rngs::StdRng, SeedableRng};
+use std::time::{Duration, Instant};
 
 use super::fs::gen_srs;
 
@@ -220,28 +221,37 @@ impl BaseTester {
         let config_params = builder.calculate_params(Some(self.unusable_rows));
 
         let params = gen_srs(self.k);
-        let vk_time = start_timer!(|| "Generating vkey");
+        let vk_timer = start_timer!(|| "Generating vkey");
+        let vk_start = Instant::now();
         let vk = keygen_vk(&params, &builder).unwrap();
-        end_timer!(vk_time);
-        let pk_time = start_timer!(|| "Generating pkey");
+        let vk_time = vk_start.elapsed();
+        end_timer!(vk_timer);
+
+        let pk_timer = start_timer!(|| "Generating pkey");
+        let pk_start = Instant::now();
         let pk = keygen_pk(&params, vk, &builder).unwrap();
-        end_timer!(pk_time);
+        let pk_time = pk_start.elapsed();
+        end_timer!(pk_timer);
 
         let break_points = builder.break_points();
         drop(builder);
         // create real proof
-        let proof_time = start_timer!(|| "Proving time");
+        let proof_timer = start_timer!(|| "Proving time");
+        let proof_start = Instant::now();
         let mut builder = RangeCircuitBuilder::prover(config_params.clone(), break_points);
         let range = RangeChip::new(self.lookup_bits.unwrap_or(0), builder.lookup_manager().clone());
         f(builder.pool(0), &range, logic_input);
         let proof = gen_proof(&params, &pk, builder);
-        end_timer!(proof_time);
+        let proof_time = proof_start.elapsed();
+        end_timer!(proof_timer);
 
         let proof_size = proof.len();
 
-        let verify_time = start_timer!(|| "Verify time");
+        let verify_timer = start_timer!(|| "Verify time");
+        let verify_start = Instant::now();
         check_proof(&params, pk.get_vk(), &proof, self.expect_satisfied);
-        end_timer!(verify_time);
+        let verify_time = verify_start.elapsed();
+        end_timer!(verify_timer);
 
         BenchStats { config_params, vk_time, pk_time, proof_time, proof_size, verify_time }
     }
@@ -252,13 +262,13 @@ pub struct BenchStats {
     /// Config params
     pub config_params: BaseCircuitParams,
     /// Vkey gen time
-    pub vk_time: TimerInfo,
+    pub vk_time: Duration,
     /// Pkey gen time
-    pub pk_time: TimerInfo,
+    pub pk_time: Duration,
     /// Proving time
-    pub proof_time: TimerInfo,
+    pub proof_time: Duration,
     /// Proof size in bytes
     pub proof_size: usize,
     /// Verify time
-    pub verify_time: TimerInfo,
+    pub verify_time: Duration,
 }

--- a/halo2-ecc/src/bn254/tests/ec_add.rs
+++ b/halo2-ecc/src/bn254/tests/ec_add.rs
@@ -102,9 +102,9 @@ fn bench_ec_add() -> Result<(), Box<dyn std::error::Error>> {
             bench_params.limb_bits,
             bench_params.num_limbs,
             bench_params.batch_size,
-            stats.proof_time.time.elapsed(),
+            stats.proof_time,
             stats.proof_size,
-            stats.verify_time.time.elapsed()
+            stats.verify_time
         )?;
     }
     Ok(())

--- a/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
+++ b/halo2-ecc/src/bn254/tests/fixed_base_msm.rs
@@ -106,9 +106,9 @@ fn bench_fixed_base_msm() -> Result<(), Box<dyn std::error::Error>> {
             bench_params.limb_bits,
             bench_params.num_limbs,
             bench_params.batch_size,
-            stats.proof_time.time.elapsed(),
+            stats.proof_time,
             stats.proof_size,
-            stats.verify_time.time.elapsed()
+            stats.verify_time
         )?;
     }
     Ok(())

--- a/halo2-ecc/src/bn254/tests/msm.rs
+++ b/halo2-ecc/src/bn254/tests/msm.rs
@@ -103,9 +103,9 @@ fn bench_msm() -> Result<(), Box<dyn std::error::Error>> {
             bench_params.num_limbs,
             bench_params.batch_size,
             bench_params.window_bits,
-            stats.proof_time.time.elapsed(),
+            stats.proof_time,
             stats.proof_size,
-            stats.verify_time.time.elapsed(),
+            stats.verify_time,
         )?;
     }
     Ok(())

--- a/halo2-ecc/src/bn254/tests/pairing.rs
+++ b/halo2-ecc/src/bn254/tests/pairing.rs
@@ -100,9 +100,9 @@ fn bench_pairing() -> Result<(), Box<dyn std::error::Error>> {
             bench_params.lookup_bits,
             bench_params.limb_bits,
             bench_params.num_limbs,
-            stats.proof_time.time.elapsed(),
+            stats.proof_time,
             stats.proof_size,
-            stats.verify_time.time.elapsed()
+            stats.verify_time
         )?;
     }
     Ok(())

--- a/halo2-ecc/src/secp256k1/tests/ecdsa.rs
+++ b/halo2-ecc/src/secp256k1/tests/ecdsa.rs
@@ -137,9 +137,9 @@ fn bench_secp256k1_ecdsa() -> Result<(), Box<dyn std::error::Error>> {
             bench_params.lookup_bits,
             bench_params.limb_bits,
             bench_params.num_limbs,
-            stats.proof_time.time.elapsed(),
+            stats.proof_time,
             stats.proof_size,
-            stats.verify_time.time.elapsed()
+            stats.verify_time
         )?;
     }
     Ok(())


### PR DESCRIPTION
## Problem

`BaseTester::bench_builder` (in `halo2-base/src/utils/testing.rs`) stores
`ark_std` `TimerInfo` values in `BenchStats`:

```rust
pub struct BenchStats {
    pub vk_time: TimerInfo,
    pub pk_time: TimerInfo,
    pub proof_time: TimerInfo,
    pub verify_time: TimerInfo,
    ...
}
```

A `TimerInfo` only holds the `Instant` at which the timer **started**. The
downstream benches read the timing later like this:

```rust
stats.proof_time.time.elapsed(),
stats.verify_time.time.elapsed(),
```

Because `.elapsed()` is called on the *start* instant at report time, each
value measures **"phase start → report time"**, not the duration of the phase
itself. Concretely:

- `proof_time.time.elapsed()` includes the whole verification step (and any
  work between proving and the CSV write).
- Earlier phases are inflated by everything that ran after them.

So the timings written to the `*.csv` bench outputs are wrong (overlapping and
inflated).

Affected bench writers: `bn254/tests/{msm, fixed_base_msm, ec_add, pairing}.rs`
and `secp256k1/tests/ecdsa.rs`.

## Fix

Measure each phase with an explicit `Instant` and store `std::time::Duration`
in `BenchStats`:

```rust
let vk_timer = start_timer!(|| "Generating vkey");
let vk_start = Instant::now();
let vk = keygen_vk(&params, &builder).unwrap();
let vk_time = vk_start.elapsed();
end_timer!(vk_timer);
```

`start_timer!`/`end_timer!` are kept purely for their log output; the recorded
value is now the actual operation time. Downstream writers use the fields
directly (`stats.proof_time` / `stats.verify_time`), which are still
`Duration`, so the `{:?}` formatting is unchanged.

## Testing

`cargo check -p halo2-base` and `cargo check -p halo2-ecc --tests` both pass.